### PR TITLE
Update button icon

### DIFF
--- a/components/button-demo.tsx
+++ b/components/button-demo.tsx
@@ -110,6 +110,20 @@ export function ButtonDemo() {
           Please wait
         </Button>
       </div>
+      <div className="flex flex-wrap items-center gap-2 md:flex-row">
+        <Button size="icon">
+          <SendIcon />
+        </Button>
+        <Button size="icon" colorScheme="success" variant="outline">
+          <SendIcon />
+        </Button>
+        <Button size="icon" colorScheme="danger" variant="outline">
+          <SendIcon />
+        </Button>
+        <Button size="icon" colorScheme="neutral" variant="outline">
+          <SendIcon />
+        </Button>
+      </div>
     </div>
   )
 }

--- a/registry/new-york/ui/button.tsx
+++ b/registry/new-york/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 const buttonVariants = cva(
-  "inline-flex h-10 min-w-10 px-4 py-2 has-[>svg]:px-4 items-center justify-center gap-2 whitespace-nowrap rounded-4xl text-md font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+  "inline-flex h-10 px-4 py-2 has-[>svg]:px-4 items-center justify-center gap-2 whitespace-nowrap rounded-4xl text-md font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
   {
     variants: {
       variant: {


### PR DESCRIPTION
- Remove `min-w-10` from the general button, as it prevents the size-9 icon from appearing perfectly round.