### PR TITLE
feat(drawer): Introduce sibling mode for non-portal rendering

### DIFF
--- a/registry/new-york/ui/drawer.tsx
+++ b/registry/new-york/ui/drawer.tsx
@@ -32,17 +32,7 @@ function DrawerClose({
 function DrawerOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay> & {
-  /**
-   * Used internally by DrawerContent to conditionally render the overlay.
-   * @internal
-   */
-  _siblingMode?: boolean
-}) {
-  if (props._siblingMode) {
-    return null
-  }
-
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
   return (
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
@@ -94,7 +84,7 @@ function DrawerContent({
 
   return (
     <DrawerPortal data-slot="drawer-portal">
-      <DrawerOverlay _siblingMode={siblingMode} />
+      <DrawerOverlay />
       {content}
     </DrawerPortal>
   )


### PR DESCRIPTION
I've added a `siblingMode` prop to our Drawer component to give us more layout flexibility. 

See it in action below:
![siblingMode](https://github.com/user-attachments/assets/23fe201b-c61f-4fd4-ab83-bd9681e2195e)

## What this solves:
By default, the shadcn/ui Drawer renders into a portal, which _teleports_ it to the end of the `<body>`. This is great for overlays, but it means the drawer lives in a separate DOM context from the rest of our app. As a result, you can't have the drawer push or resize adjacent content, which is a necessary pattern for our media project.

The new minimal and optional, `siblingMode` renders the drawer inline, as a direct sibling to your other components, while still giving all the benefits of the drawer component.

## Why the base component change?
I looked into creating a wrapper component first, but the portal logic is baked into the Drawer's core. Modifying the base component was the cleanest way to introduce this functionality as an opt-in feature without breaking existing behavior.
This should make building integrated side-panels much easier. Let me know what you think!