### PR TITLE
Integration of the breadcrumb component to the doc site

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,5 +1,6 @@
+import { mdiDotsHorizontal, mdiSlashForward } from "@mdi/js";
+import Icon from "@mdi/react";
 import { Slot } from "@radix-ui/react-slot";
-import { ChevronRight, MoreHorizontal } from "lucide-react";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -13,7 +14,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        "flex flex-wrap items-center gap-1.5 break-words text-muted-foreground text-sm sm:gap-2.5",
+        "text-muted-foreground flex flex-wrap items-center gap-1.5 text-sm break-words sm:gap-2.5",
         className,
       )}
       {...props}
@@ -43,7 +44,7 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn("transition-colors hover:text-foreground", className)}
+      className={cn("hover:text-foreground transition-colors", className)}
       {...props}
     />
   );
@@ -54,9 +55,10 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
     <span
       data-slot="breadcrumb-page"
       role="link"
+      tabIndex={0}
       aria-disabled="true"
       aria-current="page"
-      className={cn("font-normal text-foreground", className)}
+      className={cn("text-foreground font-normal", className)}
       {...props}
     />
   );
@@ -75,7 +77,7 @@ function BreadcrumbSeparator({
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? <ChevronRight />}
+      {children ?? <Icon path={mdiSlashForward} size={0.9} />}
     </li>
   );
 }
@@ -92,7 +94,7 @@ function BreadcrumbEllipsis({
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <Icon path={mdiDotsHorizontal} size={0.9} className="h-4 w-4" />
       <span className="sr-only">More</span>
     </span>
   );


### PR DESCRIPTION
**Summary**
Implemented Breadcrumb component in the demo directory.
This adds consistent UI and demo usage for Breadcrumb across the project.

**Changes**
Implemented Breadcrumb component in src/components/ui/breadcrumb.tsx
Tested the Breadcrumb component locally.

**Notes**
Added "tabIndex" attribute to BreadcrumbPage (in src/components/ui/breadcrumb.tsx) in order to make the element focusable
<img width="1118" height="332" alt="Screenshot 2025-08-28 114020" src="https://github.com/user-attachments/assets/aab99840-8b0d-4f1d-90d6-72ca92fe9986" />
