### PR TITLE
feat(textArea): add registry and demo components for TextArea

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -920,6 +920,21 @@
       ]
     },
     {
+      "name": "textarea",
+      "type": "registry:ui",
+      "title": "Textarea",
+      "description": "A textarea component for multi-line text input with various states and configurations.",
+      "registryDependencies": [
+        "https://blok-shadcn.vercel.app/r/theme.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/textarea.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "toggle-group",
       "type": "registry:ui",
       "title": "Toggle Group",

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -42,6 +42,7 @@ import { sonner } from "@/app/demo/[name]/ui/sonner";
 import { switchComponent } from "@/app/demo/[name]/ui/switch";
 import { table } from "@/app/demo/[name]/ui/table";
 import { tabs } from "@/app/demo/[name]/ui/tabs";
+import { textarea } from "@/app/demo/[name]/ui/textarea";
 import { toggleGroup } from "@/app/demo/[name]/ui/toggle-group";
 import { tooltip } from "@/app/demo/[name]/ui/tooltip";
 import { pagination } from "@/app/demo/[name]/ui/pagination";
@@ -96,6 +97,7 @@ export const demos: { [name: string]: Demo } = {
   sonner,
   table,
   tabs,
+  textarea,
   "toggle-group": toggleGroup,
   tooltip,
   pagination,

--- a/src/app/demo/[name]/ui/textarea.tsx
+++ b/src/app/demo/[name]/ui/textarea.tsx
@@ -1,0 +1,92 @@
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+export const textarea = {
+  name: "textarea",
+  components: {
+    // Basic textarea
+    Basic: <Textarea placeholder="Type your message here." />,
+    
+    // Invalid state
+    Invalid: <Textarea placeholder="Type your message here." aria-invalid="true" />,
+    
+    // With label
+    WithLabel: (
+      <div className="grid gap-3">
+        <Label htmlFor="textarea-demo-message">Message</Label>
+        <Textarea
+          id="textarea-demo-message"
+          placeholder="Type your message here."
+          rows={6}
+        />
+      </div>
+    ),
+    
+    // With label and description
+    WithLabelAndDescription: (
+      <div className="grid gap-3">
+        <Label htmlFor="textarea-demo-message-2">
+          Message
+        </Label>
+        <Textarea
+          id="textarea-demo-message-2"
+          placeholder="Type your message here."
+          rows={6}
+        />
+        <div className="text-muted-foreground text-sm">
+          Type your message and press enter to send.
+        </div>
+      </div>
+    ),
+    
+    // Disabled state
+    Disabled: (
+      <div className="grid gap-3">
+        <Label htmlFor="textarea-demo-disabled">Disabled Textarea</Label>
+        <Textarea
+          id="textarea-demo-disabled"
+          placeholder="Type your message here."
+          disabled
+        />
+      </div>
+    ),
+    
+    // Small size
+    Small: (
+      <div className="grid gap-3">
+        <Label htmlFor="small-textarea">Small (3 rows)</Label>
+        <Textarea
+          id="small-textarea"
+          placeholder="Small textarea"
+          rows={3}
+          className="min-h-[60px]"
+        />
+      </div>
+    ),
+    
+    // Large size
+    Large: (
+      <div className="grid gap-3">
+        <Label htmlFor="large-textarea">Large (8 rows)</Label>
+        <Textarea
+          id="large-textarea"
+          placeholder="Large textarea"
+          rows={8}
+          className="min-h-[160px]"
+        />
+      </div>
+    ),
+    
+    // With default value
+    WithDefaultValue: (
+      <div className="grid gap-3">
+        <Label htmlFor="textarea-with-value">Pre-filled Textarea</Label>
+        <Textarea
+          id="textarea-with-value"
+          defaultValue="This textarea comes with some pre-filled content. You can edit this text or add more content as needed."
+          rows={4}
+        />
+      </div>
+    ),
+  },
+};

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,8 +7,8 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "field-sizing-content flex min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
-        className,
+        "border-input placeholder:text-muted-foreground focus-visible:border-primary focus-visible:ring-primary focus:ring-primary aria-invalid:ring-destructive dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 text-md flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 transition-[color] outline-none focus:ring-1 focus-visible:ring-[1px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
       )}
       {...props}
     />


### PR DESCRIPTION
**New Component to the doc site**

**Summary**

- Implemented textarea component in both the registry and demo directories.
- This adds consistent UI and demo usage for textarea across the project.

**Changes**

- Implemented textarea component in `src/components/ui/textarea.tsx`
- Created demo component for textarea in `src/app/demo/[name]/ui/textarea.tsx`
- Added the new textArea component into the `registry.json`
- Added the textarea to use in the doc site at `src/app/demo/[name]/ui/index.tsx`
- Tested the textarea component locally.