### PR TITLE
Integration of the hover card component to the doc site

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -954,6 +954,21 @@
           "target": "src/components/ui/tooltip.tsx"
         }
       ]
+    },
+    {
+      "name": "hover-card",
+      "type": "registry:ui",
+      "title": "Hover Card",
+      "description": "For sighted users to preview content available behind a link.",
+      "registryDependencies": ["https://blok-shadcn.vercel.app/r/theme.json"],
+      "dependencies": ["@radix-ui/react-hover-card"],
+      "files": [
+        {
+          "path": "src/components/ui/hover-card.tsx",
+          "type": "registry:ui",
+          "target": "src/components/ui/hover-card.tsx"
+        }
+      ]
     }
   ]
 }

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -45,6 +45,7 @@ import { tabs } from "@/app/demo/[name]/ui/tabs";
 import { toggleGroup } from "@/app/demo/[name]/ui/toggle-group";
 import { tooltip } from "@/app/demo/[name]/ui/tooltip";
 import { pagination } from "@/app/demo/[name]/ui/pagination";
+import { hoverCard } from "@/app/demo/[name]/ui/hover-card";
 
 interface Demo {
   name: string; // this must match the `registry.json` name
@@ -99,4 +100,5 @@ export const demos: { [name: string]: Demo } = {
   "toggle-group": toggleGroup,
   tooltip,
   pagination,
+  "hover-card": hoverCard,
 };

--- a/src/app/demo/[name]/ui/hover-card.tsx
+++ b/src/app/demo/[name]/ui/hover-card.tsx
@@ -1,0 +1,46 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { mdiCalendar } from "@mdi/js";
+import Icon from "@mdi/react";
+
+export const hoverCard = {
+  name: "hover-card",
+  components: {
+    Default: (
+      <HoverCard>
+        <HoverCardTrigger asChild>
+          <Button variant="link">@nextjs</Button>
+        </HoverCardTrigger>
+        <HoverCardContent className="w-80" side="right">
+          <div className="flex justify-between gap-4">
+            <Avatar>
+              <AvatarImage src="https://github.com/vercel.png" />
+              <AvatarFallback>VC</AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-1">
+              <h4 className="text-sm font-semibold text-foreground">@nextjs</h4>
+              <p className="text-sm text-muted-foreground">
+                The React Framework – created and maintained by @vercel.
+              </p>
+              <div className="mt-1 flex items-center gap-2">
+                <Icon
+                  path={mdiCalendar}
+                  size={0.875}
+                  className="text-muted-foreground"
+                />
+                <span className="text-muted-foreground text-xs">
+                  Joined December 2021
+                </span>
+              </div>
+            </div>
+          </div>
+        </HoverCardContent>
+      </HoverCard>
+    ),
+  },
+};

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -32,8 +32,8 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=closed]:animate-out data-[state=open]:animate-in",
-          className,
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
         )}
         {...props}
       />


### PR DESCRIPTION
### Summary
Implemented **hover card** component in both the `registry` and `demo` directories.  
This adds consistent UI and demo usage for hover card across the project.

### Changes
- Implemented `hover card` component in `src/components/ui/hover-card.tsx`
- Created demo component for hover card in `src/app/demo/[name]/ui/hover-card.tsx`
- Add the demo `hover card` component to the index file to show in the site in `src/app/demo/[name]/index.tsx`
- Tested the `hover card` component locally.



**Note**
The `hover card` component needs to be registered in `registry.json`; as this component doesn't exist in the site or registry.