### PR TITLE
feat(inputOtp): add registry and demo components for inputOtp

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -704,6 +704,27 @@
       ]
     },
     {
+      "name": "inputOtp",
+      "type": "registry:ui",
+      "title": "InputOtp",
+      "description": "A one-time password input component for verification codes.",
+      "dependencies": [
+        "@mdi/js", 
+        "@mdi/react", 
+        "input-otp"
+      ],
+      "registryDependencies": [
+        "https://blok-shadcn.vercel.app/r/theme.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/inputOtp.tsx",
+          "type": "registry:ui",
+          "target": "src/components/ui/inputOtp.tsx"
+        }
+      ]
+    },
+    {
       "name": "label",
       "type": "registry:ui",
       "title": "Label",

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -32,6 +32,7 @@ import { datePicker } from "@/app/demo/[name]/ui/date-picker";
 import { dialog } from "@/app/demo/[name]/ui/dialog";
 import { dropdownMenu } from "@/app/demo/[name]/ui/dropdown-menu";
 import { input } from "@/app/demo/[name]/ui/input";
+import { inputOtp } from "@/app/demo/[name]/ui/inputOtp";
 import { label } from "@/app/demo/[name]/ui/label";
 import { menuBar } from "@/app/demo/[name]/ui/menu-bar";
 import { select } from "@/app/demo/[name]/ui/select";
@@ -86,6 +87,7 @@ export const demos: { [name: string]: Demo } = {
   "data-table": dataTable,
   "dropdown-menu": dropdownMenu,
   input,
+  inputOtp,
   label,
   "menu-bar": menuBar,
   select,

--- a/src/app/demo/[name]/ui/inputOtp.tsx
+++ b/src/app/demo/[name]/ui/inputOtp.tsx
@@ -1,0 +1,57 @@
+import { Label } from "@/components/ui/label";
+import { InputOTP, InputOTPGroup, InputOTPSeparator, InputOTPSlot } from "@/components/ui/inputOtp";
+
+export const inputOtp = {
+  name: "inputOtp",
+  components: {
+    Default: (
+      <div className="grid gap-2 p-5">
+        <Label htmlFor="simple">Simple</Label>
+        <InputOTP id="simple" maxLength={6}>
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+          </InputOTPGroup>
+          <InputOTPSeparator />
+          <InputOTPGroup>
+            <InputOTPSlot index={3} />
+            <InputOTPSlot index={4} />
+            <InputOTPSlot index={5} />
+          </InputOTPGroup>
+        </InputOTP>
+      </div>
+    ),
+    Pattern: (
+      <div className="grid gap-2 p-5">
+        <Label htmlFor="digits-only">Digits Only</Label>
+        <InputOTP id="digits-only" maxLength={6} >
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+            <InputOTPSlot index={3} />
+            <InputOTPSlot index={4} />
+            <InputOTPSlot index={5} />
+          </InputOTPGroup>
+        </InputOTP>
+      </div>
+    ),
+    // With Spacing
+    WithSpacing: (
+      <div className="grid gap-2 p-5">
+        <Label htmlFor="with-spacing">With Spacing</Label>
+        <InputOTP id="with-spacing" maxLength={6}>
+          <InputOTPGroup className="gap-2 *:data-[slot=input-otp-slot]:rounded-md *:data-[slot=input-otp-slot]:border">
+            <InputOTPSlot index={0} aria-invalid="true" />
+            <InputOTPSlot index={1} aria-invalid="true" />
+            <InputOTPSlot index={2} aria-invalid="true" />
+            <InputOTPSlot index={3} aria-invalid="true" />
+          </InputOTPGroup>
+        </InputOTP>
+      </div>
+    ),
+    
+  },
+};
+ 

--- a/src/components/ui/inputOtp.tsx
+++ b/src/components/ui/inputOtp.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import * as React from "react";
+import { mdiMinus } from "@mdi/js";
+import Icon from "@mdi/react";
+import { OTPInput, OTPInputContext } from "input-otp";
+
+import { cn } from "@/lib/utils";
+
+function InputOTP({
+  className,
+  containerClassName,
+  ...props
+}: React.ComponentProps<typeof OTPInput> & {
+  containerClassName?: string
+}) {
+  return (
+    <OTPInput
+      data-slot="input-otp"
+      containerClassName={cn(
+        "flex items-center gap-2 has-disabled:opacity-50",
+        containerClassName
+      )}
+      className={cn("disabled:cursor-not-allowed", className)}
+      {...props}
+    />
+  );
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-otp-group"
+      className={cn("flex items-center", className)}
+      {...props}
+    />
+  );
+}
+
+function InputOTPSlot({
+  index,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  index: number
+}) {
+  const inputOTPContext = React.useContext(OTPInputContext)
+  const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
+
+  return (
+    <div
+      data-slot="input-otp-slot"
+      data-active={isActive}
+      className={cn(
+        "data-[active=true]:border-ring data-[active=true]:ring-primary-500 data-[active=true]:aria-invalid:ring-destructive dark:data-[active=true]:aria-invalid:ring-destructive/40 aria-invalid:border-destructive data-[active=true]:aria-invalid:border-destructive dark:bg-input/30 border-input text-md relative flex h-9 w-9 items-center justify-center border-y border-r transition-all outline-none first:rounded-l-md first:border-l last:rounded-r-md data-[active=true]:z-10 data-[active=true]:ring-[2px]",
+        className
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="animate-caret-blink bg-foreground h-4 w-px duration-1000" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
+  return (
+    <div data-slot="input-otp-separator" role="separator" {...props}>
+      <Icon path={mdiMinus} size={0.9} className="text-muted-foreground" />
+    </div>
+  );
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator };


### PR DESCRIPTION
**New component to the site**

**Summary**

- Implemented inputOtp component in both the registry and demo directories.
- This adds consistent UI and demo usage for inputOtp across the project.

**Changes**

- Implemented inputOtp component in `src/components/ui/inputOtp.tsx`
- Created demo component for inputOtp `in` src/app/demo/[name]/ui/inputOtp.tsx
- Tested the inputOtp component locally.