### PR TITLE
copy button border radius bug fix

### DIFF
--- a/src/components/registry/component-card.tsx
+++ b/src/components/registry/component-card.tsx
@@ -66,7 +66,8 @@ export function ComponentCard({
                       <Button
                         onClick={copyToClipboard}
                         variant="outline"
-                        className="p-4 rounded-full aspect-square"
+                        size="icon-lg"
+                        className="p-4"
                         aria-label="Copy npx command to clipboard"
                       >
                         {copied ? (


### PR DESCRIPTION
Bug Fix - Buttons of size 'icon' should always be fully-circular, not just rounded 