### PR TITLE
Set bottom positioned tooltip as default and deleted other options

### DIFF
--- a/src/app/demo/[name]/ui/tooltip.tsx
+++ b/src/app/demo/[name]/ui/tooltip.tsx
@@ -11,36 +11,12 @@ export const tooltip = {
   components: {
     side: (
       <TooltipProvider>
-        <div className="flex mt-10 gap-4">
-          {/* Top Tooltip */}
+        <div className="flex gap-4">
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="outline">Hover Top</Button>
+              <Button variant="outline">Hover</Button>
             </TooltipTrigger>
-            <TooltipContent side="top">Add to library (Top)</TooltipContent>
-          </Tooltip>
-          {/* Bottom Tooltip */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="outline">Hover Bottom</Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              Add to library (Bottom)
-            </TooltipContent>
-          </Tooltip>
-          {/* Right Tooltip */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="outline">Hover Right</Button>
-            </TooltipTrigger>
-            <TooltipContent side="right">Add to library (Right)</TooltipContent>
-          </Tooltip>
-          {/* Left Tooltip */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="outline">Hover Left</Button>
-            </TooltipTrigger>
-            <TooltipContent side="left">Add to library (Left)</TooltipContent>
+            <TooltipContent side="bottom">Add to library</TooltipContent>
           </Tooltip>
         </div>
       </TooltipProvider>


### PR DESCRIPTION
This PR addresses UI suggestion in the tooltip component: https://sitecore.atlassian.net/wiki/spaces/SDS/pages/6487015845/Bug+Bash+19+9+25#Tooltip

### Summary
Set bottom positioned tooltip as default and deleted other options 