### PR TITLE
Bug Fix: Responsiveness Bug in Topbar

### DIFF
--- a/src/components/ui/top-bar.tsx
+++ b/src/components/ui/top-bar.tsx
@@ -25,7 +25,7 @@ export default function Topbar() {
             <span className="text-xl font-bold text-red-500">
               <img
                 alt="Logo"
-                className="rounded-md object-cover object-left p-1"
+                className="flex-shrink-0 flex-grow-0 rounded-md object-cover object-left p-1"
                 src="https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/logo-sitecore"
               />
             </span>
@@ -33,7 +33,7 @@ export default function Topbar() {
         </div>
 
         {/* Navigation Menu */}
-        <NavigationMenu className="ml-6">
+        <NavigationMenu className="ml-6 md:inline-flex hidden">
           <NavigationMenuList>
             <NavigationMenuItem>
               <NavigationMenuLink


### PR DESCRIPTION
**Summary**
Changed the navigation menu to to be displayed only in the large viewport sizes

**Changes**
- Changed CSS to display the navigation menu only after `lg` port sizes.
- Restricted the logo from shrinking and growing in different viewport sizes.