### PR TITLE
Add padding spacing above 'Dimensions' title

### DIFF
--- a/src/app/demo/[name]/ui/popover.tsx
+++ b/src/app/demo/[name]/ui/popover.tsx
@@ -19,7 +19,7 @@ export const popover = {
           <PopoverContent className="w-80" align="start">
             <div className="grid gap-4">
               <div className="grid gap-1.5">
-                <h4 className="leading-none font-medium">Dimensions</h4>
+                <h4 className="leading-none font-medium pt-5">Dimensions</h4>
                 <p className="text-muted-foreground text-sm">
                   Set the dimensions for the layer.
                 </p>


### PR DESCRIPTION
This PR addresses UI issue in the popover component:
https://sitecore.atlassian.net/wiki/spaces/SDS/pages/6487015845/Bug+Bash+19+9+25#Popover

###summary
Increased top padding above 'Dimensions' title to pt-5 for better spacing as requested by design team