### PR TITLE
Final Registry Theme

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -463,7 +463,7 @@
         "class-variance-authority"
       ],
       "registryDependencies": [
-        "http://localhost:3000/r/theme.json"
+        "https://blok-shadcn.vercel.app/r/theme.json"
       ],
       "files": [
         {


### PR DESCRIPTION
- All css variable are added to the registries cssVars object => Theme object
- All semantic variables that use the cssVars variables resides in the css objects => root object 
- dark theme is left empty as it is still in development
- targets for all implemented components are removed as it effects react cross platform support.
- all css files (global , typography, shadow ... etc) imports are removed as all the css variables are added directly to the registry object.