### PR TITLE
fix(theme): add dynamic warning and info color variables into registry

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -286,6 +286,8 @@
           "--color-destructive": "var(--destructive)",
           "--color-success": "var(--success)",
           "--color-danger": "var(--destructive)",
+          "--color-warning": "var(--warning)",
+          "--color-info": "var(--info)",
           "--color-neutral": "var(--neutral)",
           "--color-border": "var(--border)",
           "--color-input": "var(--input)",


### PR DESCRIPTION
### Summary
Added the following missing CSS variables to improve theme adaptability:
- `--color-warning`: dynamically maps to `var(--warning)`
- `--color-info`: dynamically maps to `var(--info)`

These changes ensure that warning and info colors automatically adjust based on whether the dark theme or light theme is active.
