### PR TITLE
Bcn/bf/alert metadata fix

### DIFF
--- a/src/app/demo/[name]/ui/alert-button-Link.tsx
+++ b/src/app/demo/[name]/ui/alert-button-Link.tsx
@@ -10,9 +10,9 @@ export function ButtonLinkAlert({
 }) {
   return (
     <Alert variant={variantProp}>
-      <AlertTitle>Button Link Alert</AlertTitle>
+      <AlertTitle>Button link {variantProp} Alert</AlertTitle>
       <AlertDescription>
-        This is button linked alert with a title and description.
+        This is a button linked alert with a title and description.
         <Button size="sm" variant="link" className="p-0">
           Click
         </Button>


### PR DESCRIPTION
Fix - content inside the button link alerts were not aligned to their variant. 