### PR TITLE
fix: use supported ARIA attributes to resolve accessibility warning

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -206,10 +206,10 @@ function CalendarDayButton({
       data-range-start={modifiers.range_start}
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
-      aria-selected={modifiers.selected || undefined}
+      aria-pressed={modifiers.selected || false}
       className={cn(
         buttonVariants({ variant: "ghost", colorScheme: "neutral" }),
-        "hover:rounded-md size-8 p-0 font-normal border border-solid border-transparent rounded-md text-body-text transition-none", 
+        "hover:rounded-md size-8 p-0 font-normal border border-solid border-transparent rounded-md text-body-text transition-none",
         !modifiers.selected &&
           !modifiers.range_start &&
           !modifiers.range_end &&


### PR DESCRIPTION
### Summary
use supported ARIA attributes to resolve accessibility warning

### Changes
Changed aria-selected to aria-pressed because aria-selected is not allowed on button elements in calendar. This caused the accessibility error: "ARIA attribute is not allowed".