### PR TITLE
Accessibility Fix: Identical Links in Sidebar

### DIFF
--- a/src/components/registry/registry-sidebar.tsx
+++ b/src/components/registry/registry-sidebar.tsx
@@ -90,9 +90,9 @@ export function RegistrySidebar() {
     <Sidebar collapsible="icon">
       <SidebarHeader className="border-b">
         <div className="flex items-center justify-between px-2 py-2">
-          <Link href="/" className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             <RegistryLogo />
-          </Link>
+          </div>
 
           <Button
             variant="ghost"


### PR DESCRIPTION
**Summary**
Both the registry logo with the text "Blok Registry (Beta)" and the navigation item "Home" have the same link destination but with different texts. Link in the registry logo was removed in this PR.