### PR TITLE
Fix: add nav landmark to sidebar content

### DIFF
--- a/src/components/registry/docsite-sidebar.tsx
+++ b/src/components/registry/docsite-sidebar.tsx
@@ -369,15 +369,17 @@ function SidebarSeparator({
   );
 }
 
-function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+function SidebarContent({ className, ...props }: React.ComponentProps<"nav">) {
   return (
-    <div
+    <nav
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
         "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
-        className,
+        className
       )}
+      role="navigation"
+      aria-label="Main navigation"
       {...props}
     />
   );
@@ -389,6 +391,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-group"
       data-sidebar="group"
       className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      role="group"
       {...props}
     />
   );


### PR DESCRIPTION
### Summary 
This PR addresses the issue where the menu must be placed within a landmark region.


### Changes
The change wraps the sidebar content in a `<nav>` element with role="navigation" and aria-label="Main navigation" to make it properly accessible to screen readers and comply with WCAG accessibility guidelines for navigation landmarks