### PR TITLE
(feat) empty state and error states primitives added

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -500,6 +500,8 @@
         "https://blok.sitecore.com/r/dialog.json",
         "https://blok.sitecore.com/r/drawer.json",
         "https://blok.sitecore.com/r/dropdown-menu.json",
+        "https://blok.sitecore.com/r/empty-states.json",
+        "https://blok.sitecore.com/r/error-states.json",
         "https://blok.sitecore.com/r/hover-card.json",
         "https://blok.sitecore.com/r/input.json",
         "https://blok.sitecore.com/r/inputOtp.json",
@@ -1046,6 +1048,46 @@
         {
           "path": "src/lib/icon.tsx",
           "type": "registry:lib"  
+        }
+      ]
+    },
+    {
+      "name": "error-states",
+      "type": "registry:ui",
+      "title": "Error States",
+      "description": "Displays error state variants for different HTTP error codes and generic errors.",
+      "dependencies": [
+        "class-variance-authority",
+        "next"
+      ],
+      "registryDependencies": [
+        "https://blok.sitecore.com/r/theme.json",
+        "https://blok.sitecore.com/r/button.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/error-states.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "empty-states",
+      "type": "registry:ui",
+      "title": "Empty States",
+      "description": "Displays empty state variants for no search results, nothing created, and error scenarios.",
+      "dependencies": [
+        "class-variance-authority",
+        "next"
+      ],
+      "registryDependencies": [
+        "https://blok.sitecore.com/r/theme.json",
+        "https://blok.sitecore.com/r/button.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/empty-states.tsx",
+          "type": "registry:ui"
         }
       ]
     },

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -18,6 +18,8 @@ import { contextMenu } from "@/app/demo/[name]/ui/context-menu";
 import { datePicker } from "@/app/demo/[name]/ui/date-picker";
 import { dialog } from "@/app/demo/[name]/ui/dialog";
 import { drawer } from "@/app/demo/[name]/ui/drawer";
+import { emptyStates } from "@/app/demo/[name]/ui/empty-states";
+import { errorStates } from "@/app/demo/[name]/ui/error-states";
 import { dropdownMenu } from "@/app/demo/[name]/ui/dropdown-menu";
 import { input } from "@/app/demo/[name]/ui/input";
 import { inputOtp } from "@/app/demo/[name]/ui/inputOtp";
@@ -89,6 +91,8 @@ export const demos: { [name: string]: Demo } = {
   drawer,
   "dropdown-menu": dropdownMenu,
   draggable,
+  "empty-states": emptyStates,
+  "error-states": errorStates,
   input,
   inputOtp,
   label,

--- a/src/app/demo/[name]/ui/empty-states.tsx
+++ b/src/app/demo/[name]/ui/empty-states.tsx
@@ -1,0 +1,23 @@
+import { EmptyStates } from "@/components/ui/empty-states";
+
+export const emptyStates = {
+  name: "empty-states",
+  components: {
+    "No Search Results": (
+      <div className="h-[300px]">
+        <EmptyStates variant="no-search-results" />
+      </div>
+    ),
+    "Nothing Created": (
+      <div className="h-[300px]">
+        <EmptyStates variant="nothing-created" />
+      </div>
+    ),
+    Error: (
+      <div className="h-[300px]">
+        <EmptyStates variant="error" />
+      </div>
+    ),
+  },
+};
+

--- a/src/app/demo/[name]/ui/error-states.tsx
+++ b/src/app/demo/[name]/ui/error-states.tsx
@@ -1,0 +1,43 @@
+import { ErrorStates } from "@/components/ui/error-states";
+
+export const errorStates = {
+  name: "error-states",
+  components: {
+    Generic: (
+      <div className="h-[400px]">
+        <ErrorStates variant="generic" />
+      </div>
+    ),
+    "Bad Request (400)": (
+      <div className="h-[400px]">
+        <ErrorStates variant="400" />
+      </div>
+    ),
+    "Unauthorized (401)": (
+      <div className="h-[400px]">
+        <ErrorStates variant="401" />
+      </div>
+    ),
+    "Forbidden (403)": (
+      <div className="h-[400px]">
+        <ErrorStates variant="403" />
+      </div>
+    ),
+    "Page Not Found (404)": (
+      <div className="h-[400px]">
+        <ErrorStates variant="404" />
+      </div>
+    ),
+    "Internal Server Error (500)": (
+      <div className="h-[400px]">
+        <ErrorStates variant="500" />
+      </div>
+    ),
+    "Service Unavailable (503)": (
+      <div className="h-[400px]">
+        <ErrorStates variant="503" />
+      </div>
+    ),
+  },
+};
+

--- a/src/components/ui/empty-states.tsx
+++ b/src/components/ui/empty-states.tsx
@@ -1,0 +1,108 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const emptyStatesVariants = cva(
+  "flex items-center justify-center h-full",
+  {
+    variants: {
+      variant: {
+        "no-search-results": "",
+        "nothing-created": "",
+        error: "",
+      },
+    },
+    defaultVariants: {
+      variant: "no-search-results",
+    },
+  }
+);
+
+interface EmptyStatesProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof emptyStatesVariants> {
+  title?: string;
+  description?: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  actions?: React.ReactNode;
+}
+
+const emptyStateConfig = {
+  "no-search-results": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-magnify-close-neutral",
+    imageAlt: "magnifier icon",
+    defaultTitle: "No search results",
+    defaultDescription: "Try a different search query.",
+  },
+  "nothing-created": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-cactus-neutral",
+    imageAlt: "desert icon",
+    defaultTitle: "No widgets yet",
+    defaultDescription: undefined,
+  },
+  error: {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-alert-circle",
+    imageAlt: "alert icon",
+    defaultTitle: "Something went wrong",
+    defaultDescription: "Description of the error.",
+  },
+};
+
+function EmptyStates({
+  className,
+  variant = "no-search-results",
+  title,
+  description,
+  imageSrc,
+  imageAlt,
+  actions,
+  ...props
+}: EmptyStatesProps) {
+  const config = emptyStateConfig[variant || "no-search-results"];
+  const finalTitle = title || config.defaultTitle;
+  const finalDescription = description || config.defaultDescription;
+  const finalImageSrc = imageSrc || config.imageSrc;
+  const finalImageAlt = imageAlt || config.imageAlt;
+
+  const defaultActions = {
+    "no-search-results": (
+      <Button variant="link">Reset search</Button>
+    ),
+    "nothing-created": (
+      <Button variant="default">Create widget</Button>
+    ),
+    error: (
+      <Button variant="link">Try again</Button>
+    ),
+  };
+
+  const finalActions = actions || defaultActions[variant || "no-search-results"];
+
+  return (
+    <div
+      data-slot="empty-states"
+      className={cn(emptyStatesVariants({ variant }), className)}
+      {...props}
+    >
+      <div className="flex flex-col items-center text-center gap-4 max-w-sm">
+        <img
+          src={finalImageSrc}
+          alt={finalImageAlt}
+          className="w-16 h-16"
+        />
+        <div className="flex flex-col items-center gap-1.5">
+          <h2 className="text-lg font-semibold">{finalTitle}</h2>
+          {finalDescription && (
+            <p className="text-sm text-muted-foreground">{finalDescription}</p>
+          )}
+        </div>
+        {finalActions}
+      </div>
+    </div>
+  );
+}
+
+export { EmptyStates, emptyStatesVariants, type EmptyStatesProps };
+

--- a/src/components/ui/error-states.tsx
+++ b/src/components/ui/error-states.tsx
@@ -1,0 +1,164 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const errorStatesVariants = cva(
+  "flex items-center justify-center h-full",
+  {
+    variants: {
+      variant: {
+        generic: "",
+        "400": "",
+        "401": "",
+        "403": "",
+        "404": "",
+        "500": "",
+        "503": "",
+      },
+    },
+    defaultVariants: {
+      variant: "generic",
+    },
+  }
+);
+
+interface ErrorStatesProps
+  extends React.ComponentProps<"div">,
+    VariantProps<typeof errorStatesVariants> {
+  title?: string;
+  description?: string;
+  errorCode?: string;
+  imageSrc?: string;
+  imageAlt?: string;
+  actions?: React.ReactNode;
+}
+
+const errorStateConfig = {
+  generic: {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-alert",
+    imageAlt: "alert",
+    defaultTitle: "Something went wrong",
+    defaultDescription: "(Customizable text) Please try again. If the issue persists, try visiting the Knowledge Base for assistance.",
+  },
+  "400": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-alert-circle",
+    imageAlt: "alert",
+    defaultTitle: "Bad request",
+    defaultDescription: "(Customizable text) Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",
+    defaultErrorCode: "Error 400",
+  },
+  "401": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-stop",
+    imageAlt: "stop",
+    defaultTitle: "Unauthorized",
+    defaultDescription: "(Customizable text) Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",
+    defaultErrorCode: "Error 401",
+  },
+  "403": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-lock",
+    imageAlt: "lock",
+    defaultTitle: "Forbidden",
+    defaultDescription: "(Customizable text) You don't have permission to access this page.",
+    defaultErrorCode: "Error 403",
+  },
+  "404": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-map-search",
+    imageAlt: "map-search",
+    defaultTitle: "Page not found",
+    defaultDescription: "The page you are looking for cannot be found.",
+    defaultErrorCode: "Error 404",
+  },
+  "500": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-alert-circle?",
+    imageAlt: "alert",
+    defaultTitle: "Internal server error",
+    defaultDescription: "(Customizable text) This page isn't working.",
+    defaultErrorCode: "Error 500",
+  },
+  "503": {
+    imageSrc: "https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-wrench-clock",
+    imageAlt: "wrench-clock",
+    defaultTitle: "Service unavailable",
+    defaultDescription: "(Customizable text) The service you requested is not available at this time.",
+    defaultErrorCode: "Error 503",
+  },
+};
+
+function ErrorStates({
+  className,
+  variant = "generic",
+  title,
+  description,
+  errorCode,
+  imageSrc,
+  imageAlt,
+  actions,
+  ...props
+}: ErrorStatesProps) {
+  const config = errorStateConfig[variant || "generic"];
+  const finalTitle = title || config.defaultTitle;
+  const finalDescription = description || config.defaultDescription;
+  const finalErrorCode = errorCode || ("defaultErrorCode" in config ? config.defaultErrorCode : undefined);
+  const finalImageSrc = imageSrc || config.imageSrc;
+  const finalImageAlt = imageAlt || config.imageAlt;
+
+  const defaultActions = {
+    generic: (
+      <div className="flex flex-col items-center gap-2">
+        <Button variant="link">Retry</Button>
+        <Button variant="link">Go to homepage</Button>
+      </div>
+    ),
+    "400": (
+      <Button variant="link">Go to homepage</Button>
+    ),
+    "401": (
+      <Button variant="link">Go to homepage</Button>
+    ),
+    "403": (
+      <Button variant="link">Go to homepage</Button>
+    ),
+    "404": (
+      <div className="flex flex-col items-center gap-2">
+        <Button variant="link">Go to homepage</Button>
+        <Button variant="link">Visit knowledge base</Button>
+      </div>
+    ),
+    "500": (
+      <Button variant="link">Go to homepage</Button>
+    ),
+    "503": (
+      <Button variant="link">Go to homepage</Button>
+    ),
+  };
+
+  const finalActions = actions || defaultActions[variant || "generic"];
+
+  return (
+    <div
+      data-slot="error-states"
+      className={cn(errorStatesVariants({ variant }), className)}
+      {...props}
+    >
+      <div className="flex flex-col items-center text-center gap-6 max-w-sm">
+        <img
+          src={finalImageSrc}
+          alt={finalImageAlt}
+          className="w-32 h-32"
+        />
+        <div className="flex flex-col items-center gap-1.5">
+          <h1 className="text-2xl font-semibold">{finalTitle}</h1>
+          {finalErrorCode && (
+            <p className="text-sm text-muted-foreground">{finalErrorCode}</p>
+          )}
+        </div>
+        <p className="text-base">{finalDescription}</p>
+        {finalActions}
+      </div>
+    </div>
+  );
+}
+
+export { ErrorStates, errorStatesVariants, type ErrorStatesProps };
+


### PR DESCRIPTION
## Summary
This PR adds two new registry components: `error-states` and `empty-states`, providing reusable UI components for displaying error and empty state scenarios.

## Components Added

### Error States (`error-states`)
Displays error state variants for different HTTP error codes and generic errors:
- **Generic** - Generic error with retry and homepage actions
- **400** - Bad request
- **401** - Unauthorized
- **403** - Forbidden
- **404** - Page not found (with homepage and knowledge base actions)
- **500** - Internal server error
- **503** - Service unavailable

### Empty States (`empty-states`)
Displays empty state variants for various scenarios:
- **No Search Results** - When search returns no results
- **Nothing Created** - When no items have been created yet
- **Error** - Generic error state for empty scenarios
