### PR TITLE
Hide primitives , hover card and drawer

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -1003,25 +1003,6 @@
       ]
     },
     {
-      "name": "drawer",
-      "type": "registry:ui",
-      "title": "Drawer",
-      "description": "A side panel containing content or editable fields.",
-      "dependencies": [
-        "vaul"
-      ],
-      "registryDependencies": [
-        "https://blok.sitecore.com/r/button.json",
-        "https://blok.sitecore.com/r/theme.json"
-      ],
-      "files": [
-        {
-          "path": "src/components/ui/drawer.tsx",
-          "type": "registry:ui"
-        }
-      ]
-    },
-    {
       "name": "dropdown-menu",
       "type": "registry:ui",
       "title": "Dropdown",
@@ -1722,24 +1703,6 @@
       "files": [
         {
           "path": "src/components/ui/popover.tsx",
-          "type": "registry:ui"
-        }
-      ]
-    },
-    {
-      "name": "hover-card",
-      "type": "registry:ui",
-      "title": "Hover card",
-      "description": "For sighted users to preview content available behind a link.",
-      "registryDependencies": [
-        "https://blok.sitecore.com/r/theme.json"
-      ],
-      "dependencies": [
-        "@radix-ui/react-hover-card"
-      ],
-      "files": [
-        {
-          "path": "src/components/ui/hover-card.tsx",
           "type": "registry:ui"
         }
       ]

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -17,7 +17,6 @@ import { checkbox } from "@/app/demo/[name]/ui/checkbox";
 import { contextMenu } from "@/app/demo/[name]/ui/context-menu";
 import { datePicker } from "@/app/demo/[name]/ui/date-picker";
 import { dialog } from "@/app/demo/[name]/ui/dialog";
-import { drawer } from "@/app/demo/[name]/ui/drawer";
 import { emptyStates } from "@/app/demo/[name]/ui/empty-states";
 import { errorStates } from "@/app/demo/[name]/ui/error-states";
 import { dropdownMenu } from "@/app/demo/[name]/ui/dropdown-menu";
@@ -47,7 +46,6 @@ import { topbar } from "@/app/demo/[name]/ui/topbar";
 import { pagination } from "@/app/demo/[name]/ui/pagination";
 import { scrollArea } from "@/app/demo/[name]/ui/scroll-area";
 import { popover } from "@/app/demo/[name]/ui/popover";
-import { hoverCard } from "@/app/demo/[name]/ui/hover-card";
 import { collapsible } from "@/app/demo/[name]/ui/collapsible";
 import { progress } from "@/app/demo/[name]/ui/progress";
 import { command } from "@/app/demo/[name]/ui/command";
@@ -94,11 +92,9 @@ export const demos: { [name: string]: Demo } = {
   "date-picker": datePicker,
   dialog,
   draggable,
-  drawer,
   "dropdown-menu": dropdownMenu,
   "empty-states": emptyStates,
   "error-states": errorStates,
-  "hover-card": hoverCard,
   icon,
   input,
   inputOtp,


### PR DESCRIPTION
Removed the drawer component and hover card component from the site and registry without deleting them , as they must not be provided publicly