### PR TITLE
update navigation menu styling and background colors

### DIFF
--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -38,7 +38,7 @@ function NavigationMenuList({
     <NavigationMenuPrimitive.List
       data-slot="navigation-menu-list"
       className={cn(
-        "group flex flex-1 list-none items-center justify-center gap-1",
+        "group flex flex-1 list-none items-center justify-center gap-1 bg-background p-2",
         className,
       )}
       {...props}
@@ -60,7 +60,7 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-neutral-fg text-md font-medium hover:bg-neutral-bg hover:text-neutral-fg focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-neutral-fg data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 [&.active]:bg-primary-bg [&.active]:text-primary-fg [&.active]:hover:bg-primary-bg [&.active]:hover:text-primary-fg",
+  "group inline-flex h-9 w-max items-center justify-center rounded-md px-4 py-2 text-neutral-fg text-md font-medium hover:bg-neutral-bg hover:text-neutral-fg focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-neutral-fg data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 [&.active]:bg-primary-bg [&.active]:text-primary-fg [&.active]:hover:bg-primary-bg [&.active]:hover:text-primary-fg",
 );
 
 function NavigationMenuTrigger({


### PR DESCRIPTION
## Changes
- Updated `NavigationMenuList` component to include background and padding styling (`bg-background p-2`)
- Removed explicit `bg-background` from `navigationMenuTriggerStyle` to rely on theme variables