### PR TITLE
Feat(ui): add description support for dropdown, combobox, and react-select options

### DIFF
--- a/src/app/content/ui/combobox-with-description.tsx
+++ b/src/app/content/ui/combobox-with-description.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxItemDescription,
+  ComboboxItemText,
+  ComboboxItemTitle,
+  ComboboxList,
+} from "@/components/ui/combobox";
+import { Icon } from "@/lib/icon";
+import { mdiInformationOutline } from "@mdi/js";
+
+type ProductItem = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+const itemsAuthoring: ProductItem[] = [
+  {
+    id: "xm-cloud",
+    label: "XM Cloud",
+    description:
+      "Cloud-native Sitecore CMS with managed hosting, previews, and deployments.",
+  },
+  {
+    id: "component-builder",
+    label: "Component Builder",
+    description:
+      "Front-end-as-a-service style guide and visual component prototyping for your brand.",
+  },
+  {
+    id: "xmc-forms",
+    label: "XMC Forms",
+    description: "Design clear, on-brand forms for use directly on the page.",
+  },
+  {
+    id: "page-builder",
+    label: "Page builder",
+    description:
+      "Create and edit pages visually, with layout, content, and multi-user authoring in one place.",
+  },
+];
+
+const itemsPlatform: ProductItem[] = [
+  {
+    id: "experience-edge",
+    label: "Experience Edge",
+    description:
+      "Deliver structured content over GraphQL and the CDN for headless experiences.",
+  },
+  {
+    id: "blok",
+    label: "Blok",
+    description:
+      "Sitecore design system for building consistent product experiences.",
+  },
+  {
+    id: "sitecore-search",
+    label: "Sitecore Search",
+    description:
+      "Unified search across content and commerce to power discovery on your sites.",
+  },
+  {
+    id: "sitecore-cdp",
+    label: "Sitecore CDP",
+    description:
+      "Unify customer profiles and activate audiences across marketing channels.",
+  },
+];
+
+export default function ComboboxWithDescriptionDemo() {
+  return (
+    <div className="flex flex-wrap items-start gap-8 p-2">
+      <div className="flex flex-col gap-2">
+        <Combobox
+          items={itemsAuthoring}
+          itemToStringValue={(item: ProductItem) => item.label}
+        >
+          <ComboboxInput placeholder="XM Cloud Authoring" className="w-72" />
+          <ComboboxContent className="min-w-[22rem]">
+            <ComboboxEmpty>No results found.</ComboboxEmpty>
+            <ComboboxList>
+              {(item: ProductItem) => (
+                <ComboboxItem key={item.id} value={item} className="py-2">
+                  <ComboboxItemText>
+                    <ComboboxItemTitle>{item.label}</ComboboxItemTitle>
+                    <ComboboxItemDescription>
+                      {item.description}
+                    </ComboboxItemDescription>
+                  </ComboboxItemText>
+                </ComboboxItem>
+              )}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Combobox
+          items={itemsPlatform}
+          itemToStringValue={(item: ProductItem) => item.label}
+        >
+          <ComboboxInput placeholder="Platform & Data" className="w-72" />
+          <ComboboxContent className="min-w-[22rem]">
+            <ComboboxEmpty>No results found.</ComboboxEmpty>
+            <ComboboxList>
+              {(item: ProductItem) => (
+                <ComboboxItem key={item.id} value={item} className="py-2">
+                  <Icon
+                    path={mdiInformationOutline}
+                    size={1}
+                    className="size-5 shrink-0 text-subtle-text"
+                  />
+                  <ComboboxItemText>
+                    <ComboboxItemTitle>{item.label}</ComboboxItemTitle>
+                    <ComboboxItemDescription>
+                      {item.description}
+                    </ComboboxItemDescription>
+                  </ComboboxItemText>
+                </ComboboxItem>
+              )}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+      </div>
+    </div>
+  );
+}

--- a/src/app/content/ui/dropdown-menu-with-description.tsx
+++ b/src/app/content/ui/dropdown-menu-with-description.tsx
@@ -1,0 +1,141 @@
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuItemDescription,
+  DropdownMenuItemText,
+  DropdownMenuItemTitle,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Icon } from "@/lib/icon";
+import { mdiInformationOutline } from "@mdi/js";
+
+type DescItem = {
+  title: string;
+  textValue: string;
+  description: string;
+};
+
+/** XM Cloud authoring: pages, components, forms (no repeated "Sitecore" on titles). */
+const itemsAuthoring: DescItem[] = [
+  {
+    title: "XM Cloud",
+    textValue: "XM Cloud",
+    description:
+      "Cloud-native Sitecore CMS with managed hosting, previews, and deployments.",
+  },
+  {
+    title: "Component Builder",
+    textValue: "Component Builder",
+    description:
+      "Front-end-as-a-service style guide and visual component prototyping for your brand.",
+  },
+  {
+    title: "XMC Forms",
+    textValue: "XMC Forms",
+    description: "Design clear, on-brand forms for use directly on the page.",
+  },
+  {
+    title: "Page builder",
+    textValue: "Page builder",
+    description:
+      "Create and edit pages visually, with layout, content, and multi-user authoring in one place.",
+  },
+];
+
+/** Delivery, design system, and customer data (separate example). */
+const itemsPlatform: DescItem[] = [
+  {
+    title: "Experience Edge",
+    textValue: "Experience Edge",
+    description:
+      "Deliver structured content over GraphQL and the CDN for headless experiences.",
+  },
+  {
+    title: "Blok",
+    textValue: "Blok",
+    description:
+      "Sitecore design system for building consistent product experiences.",
+  },
+  {
+    title: "Sitecore Search",
+    textValue: "Sitecore Search",
+    description:
+      "Unified search across content and commerce to power discovery on your sites.",
+  },
+  {
+    title: "Sitecore CDP",
+    textValue: "Sitecore CDP",
+    description:
+      "Unify customer profiles and activate audiences across marketing channels.",
+  },
+];
+
+export default function DropdownMenuWithDescriptionDemo() {
+  return (
+    <div className="flex flex-wrap items-start gap-8">
+      <div className="flex flex-col gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" colorScheme="neutral">
+              XM Cloud Authoring
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-[22rem]">
+            <DropdownMenuGroup>
+              {itemsAuthoring.map(({ title, textValue, description }) => (
+                <DropdownMenuItem
+                  key={textValue}
+                  className="py-2"
+                  textValue={textValue}
+                >
+                  <DropdownMenuItemText>
+                    <DropdownMenuItemTitle>{title}</DropdownMenuItemTitle>
+                    <DropdownMenuItemDescription>
+                      {description}
+                    </DropdownMenuItemDescription>
+                  </DropdownMenuItemText>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" colorScheme="neutral">
+              Platform & Data
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-[22rem]">
+            <DropdownMenuGroup>
+              {itemsPlatform.map(({ title, textValue, description }) => (
+                <DropdownMenuItem
+                  key={textValue}
+                  className="py-2"
+                  textValue={textValue}
+                >
+                  <Icon
+                    path={mdiInformationOutline}
+                    size={1}
+                    className="size-5 shrink-0 text-subtle-text"
+                  />
+                  <DropdownMenuItemText>
+                    <DropdownMenuItemTitle>{title}</DropdownMenuItemTitle>
+                    <DropdownMenuItemDescription>
+                      {description}
+                    </DropdownMenuItemDescription>
+                  </DropdownMenuItemText>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/src/app/content/ui/dropdown-menu-with-description.tsx
+++ b/src/app/content/ui/dropdown-menu-with-description.tsx
@@ -18,7 +18,6 @@ type DescItem = {
   description: string;
 };
 
-/** XM Cloud authoring: pages, components, forms (no repeated "Sitecore" on titles). */
 const itemsAuthoring: DescItem[] = [
   {
     title: "XM Cloud",
@@ -45,7 +44,6 @@ const itemsAuthoring: DescItem[] = [
   },
 ];
 
-/** Delivery, design system, and customer data (separate example). */
 const itemsPlatform: DescItem[] = [
   {
     title: "Experience Edge",

--- a/src/app/content/ui/select-react.tsx
+++ b/src/app/content/ui/select-react.tsx
@@ -7,7 +7,12 @@ const productOptions: SelectReactOption[] = [
   { value: "XMCloud", label: "XM Cloud" },
   { value: "contentHub", label: "Content Hub" },
   { value: "CDP", label: "CDP" },
-  { value: "Blok", label: "Blok", disabled: true },
+  {
+    value: "Blok",
+    label: "Blok",
+    description:
+      "Sitecore design system for building consistent product experiences.",
+  },
 ];
 
 export default function SelectReactDemo() {

--- a/src/app/demo/[name]/ui/combobox.tsx
+++ b/src/app/demo/[name]/ui/combobox.tsx
@@ -111,5 +111,6 @@ export const combobox = {
     "Custom Items": { component: "combobox-custom-items" },
     "Auto Highlight": { component: "combobox-auto-highlight" },
     "Input Group": { component: "combobox-input-group" },
+    "Combobox With Description": { component: "combobox-with-description" },
   },
 };

--- a/src/app/demo/[name]/ui/dropdown-menu.tsx
+++ b/src/app/demo/[name]/ui/dropdown-menu.tsx
@@ -17,5 +17,8 @@ export const dropdownMenu = {
     "Dropdown Menu With Avatar": { component: "dropdown-menu-avatar" },
     "Dropdown Menu Avatar Only": { component: "dropdown-menu-avatar-only" },
     "Dropdown Menu Icon Color": { component: "dropdown-menu-icon-color" },
+    "Dropdown Menu With Description": {
+      component: "dropdown-menu-with-description",
+    },
   },
 };

--- a/src/app/demo/[name]/ui/select-react.tsx
+++ b/src/app/demo/[name]/ui/select-react.tsx
@@ -29,6 +29,11 @@ export const selectReact = {
   { value: "option1", label: "Option 1" },
   { value: "option2", label: "Option 2" },
   { value: "option3", label: "Option 3", disabled: true },
+  {
+    value: "blok",
+    label: "Blok",
+    description: "Optional secondary line in the menu (uses text-subtle-text).",
+  },
 ];
 
 <SelectReact

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -149,6 +149,45 @@ function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
   );
 }
 
+function ComboboxItemText({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="combobox-item-text"
+      className={cn("flex min-w-0 flex-1 flex-col gap-0.5", className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxItemTitle({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="combobox-item-title"
+      className={cn("text-sm font-semibold leading-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxItemDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="combobox-item-description"
+      className={cn("text-xs leading-snug text-subtle-text", className)}
+      {...props}
+    />
+  );
+}
+
 function ComboboxItem({
   className,
   children,
@@ -159,6 +198,8 @@ function ComboboxItem({
       data-slot="combobox-item"
       className={cn(
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "has-data-[slot=combobox-item-description]:items-start",
+        "has-data-[slot=combobox-item-description]:[&>svg:first-child]:mt-0.5",
         className,
       )}
       {...props}
@@ -313,6 +354,9 @@ export {
   ComboboxContent,
   ComboboxList,
   ComboboxItem,
+  ComboboxItemText,
+  ComboboxItemTitle,
+  ComboboxItemDescription,
   ComboboxGroup,
   ComboboxLabel,
   ComboboxCollection,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -85,7 +85,6 @@ function DropdownMenuItem({
   );
 }
 
-/** Column for title + optional description inside `DropdownMenuItem`. */
 function DropdownMenuItemText({
   className,
   ...props

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -76,8 +76,50 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "hover:text-foreground focus:text-foreground data-[variant=destructive]:hover:text-destructive data-[variant=destructive]:hover:bg-destructive/10 dark:data-[variant=destructive]:hover:bg-destructive/20 data-[variant=destructive]:hover:*:[svg]:!text-destructive relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none hover:bg-neutral-bg focus:bg-neutral-bg data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-[0.8rem] [&_svg:not([class*='text-'])]:text-neutral-fg",
+        "has-data-[slot=dropdown-menu-item-description]:items-start",
+        "has-data-[slot=dropdown-menu-item-description]:[&>svg:first-child]:mt-0.5",
         className,
       )}
+      {...props}
+    />
+  );
+}
+
+/** Column for title + optional description inside `DropdownMenuItem`. */
+function DropdownMenuItemText({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dropdown-menu-item-text"
+      className={cn("flex min-w-0 flex-1 flex-col gap-0.5", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItemTitle({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dropdown-menu-item-title"
+      className={cn("text-sm font-semibold leading-tight", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuItemDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dropdown-menu-item-description"
+      className={cn("text-xs leading-snug text-subtle-text", className)}
       {...props}
     />
   );
@@ -247,6 +289,9 @@ export {
   DropdownMenuGroup,
   DropdownMenuLabel,
   DropdownMenuItem,
+  DropdownMenuItemText,
+  DropdownMenuItemTitle,
+  DropdownMenuItemDescription,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,

--- a/src/components/ui/select-react.tsx
+++ b/src/components/ui/select-react.tsx
@@ -22,6 +22,7 @@ import { cn } from "@/lib/utils";
 export type SelectReactOption = {
   value: string;
   label: string;
+  description?: string;
   disabled?: boolean;
   icon?: React.ReactNode;
 };
@@ -94,13 +95,36 @@ function CustomOption<
   Group extends GroupBase<Option>,
 >(props: OptionProps<Option, IsMulti, Group>) {
   const { isSelected, data } = props;
+  const hasDescription = Boolean(data.description);
   return (
     <components.Option {...props}>
-      <div className="flex w-full items-center gap-2">
-        {data.icon && <span className="shrink-0">{data.icon}</span>}
-        <span className="flex-1">{props.children}</span>
+      <div
+        className={cn(
+          "flex w-full gap-2",
+          hasDescription ? "items-start py-1" : "items-center",
+        )}
+      >
+        {data.icon && (
+          <span className={cn("shrink-0", hasDescription && "mt-0.5")}>
+            {data.icon}
+          </span>
+        )}
+        <span className="min-w-0 flex-1">
+          {hasDescription ? (
+            <span className="flex flex-col gap-0.5">
+              <span className="text-sm font-semibold leading-tight">
+                {data.label}
+              </span>
+              <span className="text-xs leading-snug text-subtle-text">
+                {data.description}
+              </span>
+            </span>
+          ) : (
+            props.children
+          )}
+        </span>
         {isSelected && (
-          <span className="shrink-0">
+          <span className={cn("shrink-0", hasDescription && "mt-0.5")}>
             <Icon path={mdiCheck} className="size-4" />
           </span>
         )}
@@ -157,10 +181,11 @@ function SelectReact<
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
       ),
     menuList: () => "p-1 max-h-[300px]",
-    option: ({ isFocused, isSelected, isDisabled: optionDisabled }) =>
+    option: ({ isFocused, isSelected, isDisabled: optionDisabled, data }) =>
       cn(
         // Base styles matching SelectItem
-        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 px-2 !text-sm outline-hidden select-none",
+        "relative flex w-full cursor-default gap-2 rounded-sm py-1.5 px-2 !text-sm outline-hidden select-none",
+        data.description ? "items-start" : "items-center",
         // Hover/focus state
         isFocused && "bg-accent text-accent-foreground",
         // Selected state

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -72,6 +72,7 @@ import DropdownMenuAvatarOnlyDemo from "@/app/content/ui/dropdown-menu-avatar-on
 import DropdownMenuCheckboxesDemo from "@/app/content/ui/dropdown-menu-checkboxes";
 import DropdownMenuIconColorDemo from "@/app/content/ui/dropdown-menu-icon-color";
 import DropdownMenuRadioGroupDemo from "@/app/content/ui/dropdown-menu-radio-group";
+import DropdownMenuWithDescriptionDemo from "@/app/content/ui/dropdown-menu-with-description";
 import EmptyStatesErrorDemo from "@/app/content/ui/empty-states-error";
 import EmptyStatesNoSearchResultsDemo from "@/app/content/ui/empty-states-no-search-results";
 import EmptyStatesNothingCreatedDemo from "@/app/content/ui/empty-states-nothing-created";
@@ -180,6 +181,7 @@ import ComboboxWithCustomItemsDemo from "@/app/content/ui/combobox-custom-items"
 import ComboboxWithGroupsAndSeparatorDemo from "@/app/content/ui/combobox-groups";
 import ComboxboxInputGroupDemo from "@/app/content/ui/combobox-input-group";
 import ComboboxMultipleDemo from "@/app/content/ui/combobox-multiple";
+import ComboboxWithDescriptionDemo from "@/app/content/ui/combobox-with-description";
 import EditableDemo from "@/app/content/ui/editable";
 import EditableTextareaDemo from "@/app/content/ui/editable-textarea";
 import FieldDemo from "@/app/content/ui/field";
@@ -210,16 +212,16 @@ import KbdGroupDemo from "@/app/content/ui/kbd-group";
 import KbdShortcutDemo from "@/app/content/ui/kbd-shortcut";
 import KbdTooltipDemo from "@/app/content/ui/kbd-tooltip";
 import SelectReactDemo from "@/app/content/ui/select-react";
+import SidebarDefaultDemo from "@/app/content/ui/sidebar-default";
+import SidebarIconCombinationDemo from "@/app/content/ui/sidebar-icon-combination";
+import SidebarLeadingIconDemo from "@/app/content/ui/sidebar-leading-icon";
+import SidebarTrailingIconDemo from "@/app/content/ui/sidebar-trailing-icon";
 import SpinnerSizeDemo from "@/app/content/ui/spinner-size";
 import StepperDemo from "@/app/content/ui/stepper";
 import TimelineDemo from "@/app/content/ui/timeline";
 import TimelineConnectorVariantsDemo from "@/app/content/ui/timeline-connector-variants";
 import TimelineSizesDemo from "@/app/content/ui/timeline-sizes";
 import TimelineVariantsDemo from "@/app/content/ui/timeline-variants";
-import SidebarDefaultDemo from "@/app/content/ui/sidebar-default";
-import SidebarLeadingIconDemo from "@/app/content/ui/sidebar-leading-icon";
-import SidebarTrailingIconDemo from "@/app/content/ui/sidebar-trailing-icon";
-import SidebarIconCombinationDemo from "@/app/content/ui/sidebar-icon-combination";
 
 export interface DocsiteRegistryEntry {
   name: string;
@@ -499,6 +501,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     path: "src/app/content/ui/combobox-multiple.tsx",
     component: ComboboxMultipleDemo,
   },
+  "combobox-with-description": {
+    name: "combobox-with-description",
+    path: "src/app/content/ui/combobox-with-description.tsx",
+    component: ComboboxWithDescriptionDemo,
+  },
   "combobox-clear-button": {
     name: "combobox-clear-button",
     path: "src/app/content/ui/combobox-clear-button.tsx",
@@ -618,6 +625,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "dropdown-menu-icon-color",
     path: "src/app/content/ui/dropdown-menu-icon-color.tsx",
     component: DropdownMenuIconColorDemo,
+  },
+  "dropdown-menu-with-description": {
+    name: "dropdown-menu-with-Description",
+    path: "src/app/content/ui/dropdown-menu-with-description.tsx",
+    component: DropdownMenuWithDescriptionDemo,
   },
   editable: {
     name: "editable",

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -275,6 +275,10 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
           { id: "combobox-custom-items", title: "Custom Items" },
           { id: "combobox-auto-highlight", title: "Auto Highlight" },
           { id: "combobox-input-group", title: "Input Group" },
+          {
+            id: "combobox-with-description",
+            title: "Combobox With Description",
+          },
         ],
       },
     ],
@@ -406,6 +410,10 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
             title: "Dropdown Menu Avatar Only",
           },
           { id: "dropdown-menu-icon-color", title: "Dropdown Menu Icon Color" },
+          {
+            id: "dropdown-menu-with-description",
+            title: "Dropdown Menu With Description",
+          },
         ],
       },
     ],


### PR DESCRIPTION

Adds composable **title + description** patterns for list-style pickers and aligns examples.

### Primitives
- **Dropdown menu:** `DropdownMenuItemText`, `DropdownMenuItemTitle`, `DropdownMenuItemDescription`; leading-icon rows align with the title when a description is present (`text-subtle-text` for secondary text).
- **Combobox:** `ComboboxItemText`, `ComboboxItemTitle`, `ComboboxItemDescription` with the same layout and description styling.
- **Select (react-select):** optional `description` on `SelectReactOption`; menu options render a secondary line when set.

### Demo examples
- **Dropdown Menu With Description:** two menus using separate authoring vs platform & data option sets; trigger labels and copy normalized (e.g. XMC Forms, no em dashes in descriptions).
- **Combobox With Description:** mirrors the same two datasets and placeholders.
- **Select React:** single control; **Blok** demonstrates the description row; other options unchanged.