### PR TITLE
[fix] add .gitattributes for LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize line endings: LF in the repository for all detected text files.
+* text=auto eol=lf


### PR DESCRIPTION
Adds a root .gitattributes with * text=auto eol=lf so text files are normalized to LF in the repo.

This reduces noisy diffs and inconsistent behavior on Windows (CRLF vs LF) when running formatters and linters like Biome.