### PR TITLE
Feat(ui): expose controlled date state and overridable labels on DatePicker

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -844,9 +844,10 @@
       "dependencies": ["date-fns", "@mdi/js", "react-day-picker"],
       "registryDependencies": [
         "https://blok.sitecore.com/r/theme.json",
-        "https://blok.sitecore.com/r/calendar.json",
         "https://blok.sitecore.com/r/button.json",
-        "https://blok.sitecore.com/r/popover.json"
+        "https://blok.sitecore.com/r/calendar.json",
+        "https://blok.sitecore.com/r/popover.json",
+        "https://blok.sitecore.com/r/select.json"
       ],
       "files": [
         {

--- a/src/app/content/ui/date-picker-range.tsx
+++ b/src/app/content/ui/date-picker-range.tsx
@@ -1,5 +1,15 @@
 import { DatePickerWithRange } from "@/components/ui/date-picker";
+import { addDays } from "date-fns";
 
 export default function DatePickerWithRangeDemo() {
-  return <DatePickerWithRange />;
+  const defaultFrom = new Date(new Date().getFullYear(), 0, 20);
+  return (
+    <DatePickerWithRange
+      defaultValue={{
+        from: defaultFrom,
+        to: addDays(defaultFrom, 20),
+      }}
+      placeholder="Pick a date range"
+    />
+  );
 }

--- a/src/app/content/ui/date-picker.tsx
+++ b/src/app/content/ui/date-picker.tsx
@@ -1,5 +1,16 @@
+"use client";
+
 import { DatePickerSimple } from "@/components/ui/date-picker";
+import * as React from "react";
 
 export default function DatePickerSimpleDemo() {
-  return <DatePickerSimple />;
+  const [date, setDate] = React.useState<Date | undefined>(() => new Date());
+
+  return (
+    <DatePickerSimple
+      value={date}
+      onChange={setDate}
+      placeholder="Pick a date"
+    />
+  );
 }

--- a/src/app/content/ui/field-input-types.tsx
+++ b/src/app/content/ui/field-input-types.tsx
@@ -25,14 +25,14 @@ export default function FieldInputTypesDemo() {
           </Field>
           <Field>
             <FieldLabel>Date Picker</FieldLabel>
-            <DatePickerSimple />
+            <DatePickerSimple placeholder="Select a date" />
             <FieldDescription>
               Select a single date using the Blok date picker.
             </FieldDescription>
           </Field>
           <Field>
             <FieldLabel>Date Range Picker</FieldLabel>
-            <DatePickerWithRange />
+            <DatePickerWithRange placeholder="Select a date range" />
             <FieldDescription>
               Select a date range using the Blok date picker.
             </FieldDescription>

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -2,7 +2,7 @@
 
 import { Icon } from "@/lib/icon";
 import { mdiCalendarBlankOutline } from "@mdi/js";
-import { addDays, format } from "date-fns";
+import { type Locale, format } from "date-fns";
 import * as React from "react";
 import type { DateRange } from "react-day-picker";
 
@@ -22,6 +22,8 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type { DropdownProps } from "react-day-picker";
+
+type CalendarProps = React.ComponentProps<typeof Calendar>;
 
 export function CustomDropdown({
   options = [],
@@ -67,18 +69,83 @@ export function CustomDropdown({
   );
 }
 
-function DatePickerSimple() {
-  const [date, setDate] = React.useState<Date>();
+export type DatePickerSimpleCalendarProps = Omit<
+  CalendarProps,
+  "mode" | "selected" | "onSelect"
+>;
+
+export type DatePickerSimpleProps = {
+  /** Uncontrolled initial selection */
+  defaultValue?: Date;
+  /** Fires when the selected date changes */
+  onChange?: (date: Date | undefined) => void;
+  /** Trigger label when empty (e.g. translated placeholder) */
+  placeholder?: React.ReactNode;
+  /** `date-fns` format string for the trigger when a date is selected */
+  dateFormat?: string;
+  /** Used with `format()` and forwarded to `Calendar` */
+  locale?: Locale;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+  /** Props forwarded to `Calendar`; `mode`, `selected`, and `onSelect` are fixed */
+  calendarProps?: DatePickerSimpleCalendarProps;
+} & (
+  | {
+      /** Controlled value; pass `undefined` to clear. Omit for uncontrolled usage. */
+      value: Date | undefined;
+    }
+  | { value?: never }
+);
+
+function DatePickerSimple(props: DatePickerSimpleProps) {
+  const {
+    defaultValue,
+    onChange,
+    placeholder = "Pick a date",
+    dateFormat = "PPP",
+    locale,
+    disabled,
+    id,
+    className,
+    calendarProps,
+  } = props;
+
+  const isControlled = "value" in props;
+  const valueProp = isControlled ? props.value : undefined;
+
+  const [internalDate, setInternalDate] = React.useState<Date | undefined>(
+    defaultValue,
+  );
+
+  const date = isControlled ? valueProp : internalDate;
+
+  const setDate = React.useCallback(
+    (next: Date | undefined) => {
+      if (!isControlled) {
+        setInternalDate(next);
+      }
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+
+  const formatOpts = locale ? { locale } : undefined;
+  const mergedLocale = locale ?? calendarProps?.locale;
 
   return (
     <Popover>
       <PopoverTrigger asChild>
         <Button
-          variant={"outline"}
-          colorScheme={"neutral"}
+          type="button"
+          id={id}
+          variant="outline"
+          colorScheme="neutral"
+          disabled={disabled}
           className={cn(
             "border-input border-1 data-[state=open]:border-2 data-[state=open]:border-primary rounded-md text-md data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 bg-body-bg px-3 py-2 whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:opacity-50 h-10",
             !date && "text-muted-foreground",
+            className,
           )}
         >
           <Icon
@@ -86,39 +153,117 @@ function DatePickerSimple() {
             size={1}
             className="text-muted-foreground"
           />
-          {date ? format(date, "PPP") : <span>Pick a date</span>}
+          {date ? (
+            format(date, dateFormat, formatOpts)
+          ) : (
+            <span>{placeholder}</span>
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
+          {...calendarProps}
           mode="single"
           selected={date}
           onSelect={setDate}
-          initialFocus
-          captionLayout="dropdown"
-          components={{ Dropdown: CustomDropdown }}
+          initialFocus={calendarProps?.initialFocus ?? true}
+          captionLayout={calendarProps?.captionLayout ?? "dropdown"}
+          locale={mergedLocale}
+          components={{
+            Dropdown: CustomDropdown,
+            ...calendarProps?.components,
+          }}
         />
       </PopoverContent>
     </Popover>
   );
 }
 
-function DatePickerWithRange() {
-  const [date, setDate] = React.useState<DateRange | undefined>({
-    from: new Date(new Date().getFullYear(), 0, 20),
-    to: addDays(new Date(new Date().getFullYear(), 0, 20), 20),
-  });
+export type DatePickerWithRangeCalendarProps = Omit<
+  CalendarProps,
+  "mode" | "selected" | "onSelect"
+>;
+
+export type DatePickerWithRangeProps = {
+  defaultValue?: DateRange;
+  onChange?: (range: DateRange | undefined) => void;
+  placeholder?: React.ReactNode;
+  /** `date-fns` format for each boundary in the trigger */
+  rangeDateFormat?: string;
+  /** Between start and end when both are set */
+  rangeSeparator?: React.ReactNode;
+  locale?: Locale;
+  disabled?: boolean;
+  id?: string;
+  className?: string;
+  calendarProps?: DatePickerWithRangeCalendarProps;
+} & ({ value: DateRange | undefined } | { value?: never });
+
+function DatePickerWithRange(props: DatePickerWithRangeProps) {
+  const {
+    defaultValue,
+    onChange,
+    placeholder = "Pick a date",
+    rangeDateFormat = "LLL dd, y",
+    rangeSeparator = " - ",
+    locale,
+    disabled,
+    id,
+    className,
+    calendarProps,
+  } = props;
+
+  const isControlled = "value" in props;
+  const valueProp = isControlled ? props.value : undefined;
+
+  const [internalRange, setInternalRange] = React.useState<
+    DateRange | undefined
+  >(defaultValue);
+
+  const range = isControlled ? valueProp : internalRange;
+
+  const setRange = React.useCallback(
+    (next: DateRange | undefined) => {
+      if (!isControlled) {
+        setInternalRange(next);
+      }
+      onChange?.(next);
+    },
+    [isControlled, onChange],
+  );
+
+  const formatOpts = locale ? { locale } : undefined;
+  const mergedLocale = locale ?? calendarProps?.locale;
+
+  const triggerLabel = (() => {
+    if (!range?.from) {
+      return <span>{placeholder}</span>;
+    }
+    if (range.to) {
+      return (
+        <>
+          {format(range.from, rangeDateFormat, formatOpts)}
+          {rangeSeparator}
+          {format(range.to, rangeDateFormat, formatOpts)}
+        </>
+      );
+    }
+    return format(range.from, rangeDateFormat, formatOpts);
+  })();
 
   return (
     <Popover>
       <PopoverTrigger asChild>
         <Button
-          id="date"
-          variant={"outline"}
-          colorScheme={"neutral"}
+          type="button"
+          id={id}
+          variant="outline"
+          colorScheme="neutral"
+          disabled={disabled}
           className={cn(
             "border-input border-1 data-[state=open]:border-2 data-[state=open]:border-primary rounded-md text-md data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 bg-body-bg px-3 py-2 whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:opacity-50 h-10",
-            !date && "text-muted-foreground",
+            !range?.from && "text-muted-foreground",
+            className,
           )}
         >
           <Icon
@@ -126,30 +271,24 @@ function DatePickerWithRange() {
             size={1}
             className="text-muted-foreground"
           />
-          {date?.from ? (
-            date.to ? (
-              <>
-                {format(date.from, "LLL dd, y")} -{" "}
-                {format(date.to, "LLL dd, y")}
-              </>
-            ) : (
-              format(date.from, "LLL dd, y")
-            )
-          ) : (
-            <span>Pick a date</span>
-          )}
+          {triggerLabel}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
-          initialFocus
+          {...calendarProps}
           mode="range"
-          defaultMonth={date?.from}
-          selected={date}
-          onSelect={setDate}
-          numberOfMonths={2}
-          captionLayout="dropdown"
-          components={{ Dropdown: CustomDropdown }}
+          defaultMonth={range?.from ?? calendarProps?.defaultMonth}
+          selected={range}
+          onSelect={setRange}
+          numberOfMonths={calendarProps?.numberOfMonths ?? 2}
+          initialFocus={calendarProps?.initialFocus ?? true}
+          captionLayout={calendarProps?.captionLayout ?? "dropdown"}
+          locale={mergedLocale}
+          components={{
+            Dropdown: CustomDropdown,
+            ...calendarProps?.components,
+          }}
         />
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
The Blok `DatePickerSimple` and `DatePickerWithRange` components no longer keep the selection only in internal state. Callers can drive the selected date or range from outside (controlled `value` + `onChange`) or use `defaultValue` for an uncontrolled setup.

Placeholder text, display formats, range separator, and `date-fns` `locale` are props so teams can wire in translations and copy without forking the component. Extra `Calendar` options can be passed through `calendarProps` where the picker does not manage `mode`, `selected`, or `onSelect`.
