### PR TITLE
[fix] updated primitivs and bloks to use blok button component

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -1291,6 +1291,7 @@
       "description": "Pinned sites shown within SitecoreAI.",
       "registryDependencies": [
         "https://blok.sitecore.com/r/theme.json",
+        "https://blok.sitecore.com/r/button.json",
         "https://blok.sitecore.com/r/all-site.json",
         "https://blok.sitecore.com/r/site-card.json"
       ],

--- a/src/app/(registry)/graphics/icons/page.tsx
+++ b/src/app/(registry)/graphics/icons/page.tsx
@@ -2,6 +2,7 @@
 
 import { copyToClipboard } from "@/components/docsite/code-block";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { CircularProgress } from "@/components/ui/circular-progress";
 import {
   Table,
@@ -685,7 +686,7 @@ export default function IconsPage() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-28 px-4">Icon</TableHead>
+                <TableHead className="w-28 px-4 ">Icon</TableHead>
                 <TableHead className="px-4">MDI link</TableHead>
                 <TableHead className="px-4">MDI code</TableHead>
                 <TableHead className="px-4">Usage</TableHead>
@@ -700,7 +701,9 @@ export default function IconsPage() {
                     >
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <button
+                          <Button
+                            variant="ghost"
+                            size="xs"
                             onClick={() => {
                               copyToClipboard(code || "");
                               track(TELEMETRY_EVENTS.copy_icon_code, {
@@ -710,14 +713,14 @@ export default function IconsPage() {
                               });
                             }}
                             aria-label={`Copy MDI code for ${mdi}`}
-                            className="cursor-pointer inline-flex items-center justify-center w-8 h-8 hover:bg-muted rounded transition-colors"
+                            className="cursor-pointer inline-flex   w-10 h-10 hover:bg-muted rounded transition-colors"
                           >
                             <Icon
                               path={icon as string}
-                              size={0.85}
+                              size={1.5}
                               className="text-foreground"
                             />
-                          </button>
+                          </Button>
                         </TooltipTrigger>
                         <TooltipContent>Copy MDI code</TooltipContent>
                       </Tooltip>
@@ -736,7 +739,9 @@ export default function IconsPage() {
                   <TableCell className="px-4">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
+                          variant="ghost"
+                          size="xs"
                           onClick={() => {
                             copyToClipboard(code || "");
                             track(TELEMETRY_EVENTS.copy_icon_code, {
@@ -748,7 +753,7 @@ export default function IconsPage() {
                           className="cursor-pointer bg-muted px-2 py-1 rounded text-sm hover:bg-muted/80 transition-colors inline-block"
                         >
                           {code}
-                        </button>
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>Copy to clipboard</TooltipContent>
                     </Tooltip>
@@ -805,7 +810,9 @@ export default function IconsPage() {
                     >
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <button
+                          <Button
+                            variant="ghost"
+                            size="lg"
                             onClick={() => {
                               copyToClipboard(icon);
                               track(TELEMETRY_EVENTS.copy_icon_code, {
@@ -818,10 +825,10 @@ export default function IconsPage() {
                           >
                             <Icon
                               path={path}
-                              size={0.85}
+                              size={1.5}
                               className="text-foreground"
                             />
-                          </button>
+                          </Button>
                         </TooltipTrigger>
                         <TooltipContent>Copy icon code</TooltipContent>
                       </Tooltip>

--- a/src/app/(registry)/graphics/illustrations/page.tsx
+++ b/src/app/(registry)/graphics/illustrations/page.tsx
@@ -2,6 +2,7 @@
 
 import { copyToClipboard } from "@/components/docsite/code-block";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -368,7 +369,9 @@ export default function IllustrationsPage() {
                   <TableCell className="px-4 min-w-[120px]">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
+                          type="button"
+                          variant="ghost"
                           onClick={() => {
                             const url = `https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-${name}`;
                             copyToClipboard(url);
@@ -377,14 +380,14 @@ export default function IllustrationsPage() {
                               href: url,
                             });
                           }}
-                          className="cursor-pointer flex items-center"
+                          className="h-auto min-h-0 cursor-pointer items-center border-0 p-0 shadow-none hover:bg-transparent"
                         >
                           <img
                             src={`https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-${name}`}
                             alt={`${name} illustration`}
                             className="max-w-[64px] h-auto object-contain"
                           />
-                        </button>
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>Copy URL</TooltipContent>
                     </Tooltip>
@@ -392,7 +395,9 @@ export default function IllustrationsPage() {
                   <TableCell className="px-4 min-w-[120px]">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
+                          type="button"
+                          variant="ghost"
                           onClick={() => {
                             const url = `https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-${name}-neutral`;
                             copyToClipboard(url);
@@ -401,14 +406,14 @@ export default function IllustrationsPage() {
                               href: url,
                             });
                           }}
-                          className="cursor-pointer flex items-center"
+                          className="h-auto min-h-0 cursor-pointer items-center border-0 p-0 shadow-none hover:bg-transparent"
                         >
                           <img
                             src={`https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/spot-${name}-neutral`}
                             alt={`${name} illustration neutral variant`}
                             className="max-w-[64px] h-auto object-contain"
                           />
-                        </button>
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>Copy URL</TooltipContent>
                     </Tooltip>

--- a/src/app/(registry)/graphics/logos/page.tsx
+++ b/src/app/(registry)/graphics/logos/page.tsx
@@ -3,6 +3,7 @@
 import { copyToClipboard } from "@/components/docsite/code-block";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Table,
@@ -308,7 +309,9 @@ export default function LogosPage() {
                   <TableCell className="px-4 py-3 min-w-[200px]">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
+                          type="button"
+                          variant="ghost"
                           onClick={() => {
                             const url = `https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/${filename}`;
                             copyToClipboard(url);
@@ -317,14 +320,14 @@ export default function LogosPage() {
                               href: url,
                             });
                           }}
-                          className="cursor-pointer h-7 flex items-center"
+                          className="h-auto min-h-0 cursor-pointer justify-start items-center border-0 p-0 shadow-none hover:bg-transparent"
                         >
                           <img
                             src={`https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/${filename}`}
                             alt={`${brand} ${type.toLowerCase()}`}
                             className="h-7 object-contain object-left"
                           />
-                        </button>
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>Copy URL</TooltipContent>
                     </Tooltip>
@@ -332,7 +335,9 @@ export default function LogosPage() {
                   <TableCell className="px-4 py-3 min-w-[200px]">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <button
+                        <Button
+                          type="button"
+                          variant="ghost"
                           onClick={() => {
                             const url = `https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/${filename}-dark`;
                             copyToClipboard(url);
@@ -341,14 +346,14 @@ export default function LogosPage() {
                               href: url,
                             });
                           }}
-                          className="cursor-pointer h-7 flex items-center"
+                          className="h-auto min-h-0 cursor-pointer justify-start items-center border-0 p-0 shadow-none hover:bg-transparent"
                         >
                           <img
                             src={`https://delivery-sitecore.sitecorecontenthub.cloud/api/public/content/${filename}-dark`}
                             alt={`${brand} ${type.toLowerCase()} dark variant`}
                             className="h-7 object-contain object-left"
                           />
-                        </button>
+                        </Button>
                       </TooltipTrigger>
                       <TooltipContent>Copy URL</TooltipContent>
                     </Tooltip>

--- a/src/app/content/bloks/sidebar-rhs-brief-type.tsx
+++ b/src/app/content/bloks/sidebar-rhs-brief-type.tsx
@@ -3,6 +3,7 @@
 import { SidebarRHS, SidebarRHSProvider } from "@/components/bloks/sidebar-rhs";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -59,12 +60,14 @@ function ExpandableDescription() {
         )}
       </div>
       {shouldTruncate && (
-        <button
+        <Button
+          type="button"
+          variant="link"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="text-sm text-center text-foreground hover:underline cursor-pointer font-semibold"
+          className="text-sm text-center font-semibold"
         >
           {isExpanded ? "Read less" : "Read more"}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -251,21 +254,27 @@ function CommentsSection() {
                   {comment.timestamp}
                 </span>
                 <div className="flex items-center gap-1 ml-auto">
-                  <button
-                    className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="p-1 text-muted-foreground shadow-none transition-colors hover:text-foreground"
                     aria-label="Reply"
                   >
                     <Icon path={mdiReplyOutline} className="size-4" />
-                  </button>
+                  </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button
-                        className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="p-1 text-muted-foreground shadow-none transition-colors hover:text-foreground"
                         aria-label="More options"
                         onClick={(e) => e.stopPropagation()}
                       >
                         <Icon path={mdiDotsHorizontal} className="size-4" />
-                      </button>
+                      </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem
@@ -325,13 +334,16 @@ function InfoSection() {
         <label className="text-xs text-muted-foreground">Label</label>
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-foreground">The label</span>
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={() => handleCopy("The label")}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground shadow-none transition-colors hover:text-foreground"
             aria-label="Copy to clipboard"
           >
             <Icon path={mdiContentCopy} className="size-4" />
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -340,13 +352,16 @@ function InfoSection() {
         <label className="text-xs text-muted-foreground">Name</label>
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-foreground">Value</span>
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={() => handleCopy("Value")}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground shadow-none transition-colors hover:text-foreground"
             aria-label="Copy to clipboard"
           >
             <Icon path={mdiContentCopy} className="size-4" />
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/app/content/bloks/sidebar-rhs-brief.tsx
+++ b/src/app/content/bloks/sidebar-rhs-brief.tsx
@@ -3,6 +3,7 @@
 import { SidebarRHS, SidebarRHSProvider } from "@/components/bloks/sidebar-rhs";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
@@ -54,12 +55,14 @@ function ExpandableDescription() {
         )}
       </div>
       {shouldTruncate && (
-        <button
+        <Button
+          type="button"
+          variant="link"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="text-sm text-center text-foreground hover:underline cursor-pointer font-semibold"
+          className="text-sm text-center font-semibold"
         >
           {isExpanded ? "Read less" : "Read more"}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -86,12 +89,15 @@ function OverviewSection() {
             </Badge>
             please review
           </span>
-          <button
-            className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 text-muted-foreground hover:text-foreground"
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="shrink-0 opacity-0 shadow-none transition-opacity group-hover:opacity-100 text-muted-foreground hover:text-foreground"
             aria-label="Delete todo"
           >
             <Icon path={mdiTrashCanOutline} size={0.9} />
-          </button>
+          </Button>
         </div>
 
         {/* Add New Todo Input */}
@@ -196,21 +202,27 @@ function CommentsSection() {
                   {comment.timestamp}
                 </span>
                 <div className="flex items-center gap-1 ml-auto">
-                  <button
-                    className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="p-1 text-muted-foreground shadow-none transition-colors hover:text-foreground"
                     aria-label="Reply"
                   >
                     <Icon path={mdiReplyOutline} className="size-4" />
-                  </button>
+                  </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button
-                        className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        className="p-1 text-muted-foreground shadow-none transition-colors hover:text-foreground"
                         aria-label="More options"
                         onClick={(e) => e.stopPropagation()}
                       >
                         <Icon path={mdiDotsHorizontal} className="size-4" />
-                      </button>
+                      </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem
@@ -270,13 +282,16 @@ function InfoSection() {
         <label className="text-xs text-muted-foreground">Label</label>
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-foreground">The label</span>
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={() => handleCopy("The label")}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground shadow-none transition-colors hover:text-foreground"
             aria-label="Copy to clipboard"
           >
             <Icon path={mdiContentCopy} className="size-4" />
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -285,13 +300,16 @@ function InfoSection() {
         <label className="text-xs text-muted-foreground">Name</label>
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-foreground">Value</span>
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={() => handleCopy("Value")}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground shadow-none transition-colors hover:text-foreground"
             aria-label="Copy to clipboard"
           >
             <Icon path={mdiContentCopy} className="size-4" />
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/src/app/content/bloks/sidebar-rhs-component.tsx
+++ b/src/app/content/bloks/sidebar-rhs-component.tsx
@@ -58,12 +58,14 @@ function ExpandableDescription() {
         )}
       </div>
       {shouldTruncate && (
-        <button
+        <Button
+          type="button"
+          variant="link"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="text-sm text-center text-foreground hover:underline cursor-pointer font-semibold"
+          className="text-sm text-center font-semibold"
         >
           {isExpanded ? "Read less" : "Read more"}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -90,12 +92,15 @@ function OverviewSection() {
             </Badge>
             please review
           </span>
-          <button
-            className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 text-muted-foreground hover:text-foreground"
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="shrink-0 opacity-0 shadow-none transition-opacity group-hover:opacity-100 text-muted-foreground hover:text-foreground"
             aria-label="Delete todo"
           >
             <Icon path={mdiTrashCanOutline} size={0.9} />
-          </button>
+          </Button>
         </div>
 
         {/* Add New Todo Input */}

--- a/src/app/content/bloks/sidebar-rhs-content.tsx
+++ b/src/app/content/bloks/sidebar-rhs-content.tsx
@@ -2,6 +2,7 @@
 
 import { SidebarRHS, SidebarRHSProvider } from "@/components/bloks/sidebar-rhs";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   type ChartConfig,
   ChartContainer,
@@ -47,12 +48,14 @@ function ExpandableDescription() {
         )}
       </div>
       {shouldTruncate && (
-        <button
+        <Button
+          type="button"
+          variant="link"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="text-sm text-center text-foreground hover:underline cursor-pointer font-semibold"
+          className="text-sm text-center font-semibold"
         >
           {isExpanded ? "Read less" : "Read more"}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -335,13 +338,16 @@ function InfoSection() {
         <label className="text-xs text-muted-foreground">Label</label>
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-foreground">The label</span>
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={() => handleCopy("The label")}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground shadow-none transition-colors hover:text-foreground"
             aria-label="Copy to clipboard"
           >
             <Icon path={mdiContentCopy} className="size-4" />
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -350,13 +356,16 @@ function InfoSection() {
         <label className="text-xs text-muted-foreground">Name</label>
         <div className="flex items-center justify-between">
           <span className="text-sm font-medium text-foreground">Value</span>
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={() => handleCopy("Value")}
-            className="text-muted-foreground hover:text-foreground transition-colors"
+            className="text-muted-foreground shadow-none transition-colors hover:text-foreground"
             aria-label="Copy to clipboard"
           >
             <Icon path={mdiContentCopy} className="size-4" />
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -392,7 +401,10 @@ function StatisticsSection() {
       <div className="grid grid-cols-[auto_auto] gap-4">
         {/* Total Variants */}
         <div className="flex flex-col gap-1 min-w-0">
-          <label htmlFor="total-variants" className="text-xs uppercase text-muted-foreground">
+          <label
+            htmlFor="total-variants"
+            className="text-xs uppercase text-muted-foreground"
+          >
             Total Variants
           </label>
           <div id="total-variants" className="flex items-baseline gap-2">
@@ -420,10 +432,15 @@ function StatisticsSection() {
 
         {/* Sites */}
         <div className="flex flex-col gap-1 shrink-0">
-          <label htmlFor="sites" className="text-xs uppercase text-muted-foreground">
+          <label
+            htmlFor="sites"
+            className="text-xs uppercase text-muted-foreground"
+          >
             Sites
           </label>
-          <span id="sites" className="text-2xl font-bold text-foreground">3</span>
+          <span id="sites" className="text-2xl font-bold text-foreground">
+            3
+          </span>
         </div>
       </div>
     </div>

--- a/src/app/content/bloks/sidebar-rhs-heading-with-tabs.tsx
+++ b/src/app/content/bloks/sidebar-rhs-heading-with-tabs.tsx
@@ -58,12 +58,14 @@ function ExpandableDescription() {
         )}
       </div>
       {shouldTruncate && (
-        <button
+        <Button
+          type="button"
+          variant="link"
           onClick={() => setIsExpanded(!isExpanded)}
-          className="text-sm text-center text-foreground hover:underline cursor-pointer font-semibold"
+          className="text-sm text-center font-semibold"
         >
           {isExpanded ? "Read less" : "Read more"}
-        </button>
+        </Button>
       )}
     </div>
   );
@@ -90,12 +92,15 @@ function OverviewSection() {
             </Badge>
             please review
           </span>
-          <button
-            className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0 text-muted-foreground hover:text-foreground"
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="shrink-0 opacity-0 shadow-none transition-opacity group-hover:opacity-100 text-muted-foreground hover:text-foreground"
             aria-label="Delete todo"
           >
             <Icon path={mdiTrashCanOutline} size={0.9} />
-          </button>
+          </Button>
         </div>
 
         {/* Add New Todo Input */}

--- a/src/app/content/ui/avatar-menu.tsx
+++ b/src/app/content/ui/avatar-menu.tsx
@@ -1,12 +1,17 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 
 export default function AvatarMenuDemo() {
   return (
     <div className="flex items-center gap-4">
       <div className="flex -space-x-2">
-        <button className="group relative flex size-12 items-center justify-center rounded-full bg-primary-background text-primary-foreground transition-colors hover:bg-primary hover:text-white">
+        <Button
+          type="button"
+          variant="ghost"
+          className="group relative flex size-12 min-h-12 min-w-12 items-center justify-center rounded-full border-0 bg-primary-background p-0 text-primary-foreground shadow-none transition-colors hover:bg-primary hover:text-white"
+        >
           <span className="text-3xl font-semibold">+</span>
-        </button>
+        </Button>
         <Avatar className="size-12 ring-2 ring-background">
           <AvatarImage
             src="https://cloudfront-us-east-1.images.arcpublishing.com/opb/UODRDCE3KTLWUWUHHRETSAXL7U.jpg"
@@ -16,9 +21,13 @@ export default function AvatarMenuDemo() {
         </Avatar>
       </div>
       <div className="flex -space-x-2">
-        <button className="group relative flex size-12 items-center justify-center rounded-full bg-primary-background text-primary-foreground transition-colors hover:bg-primary hover:text-white">
+        <Button
+          type="button"
+          variant="ghost"
+          className="group relative flex size-12 min-h-12 min-w-12 items-center justify-center rounded-full border-0 bg-primary-background p-0 text-primary-foreground shadow-none transition-colors hover:bg-primary hover:text-white"
+        >
           <span className="text-3xl font-semibold">+</span>
-        </button>
+        </Button>
         <Avatar className="size-12 ring-2 ring-background">
           <AvatarImage
             src="https://cloudfront-us-east-1.images.arcpublishing.com/opb/UODRDCE3KTLWUWUHHRETSAXL7U.jpg"
@@ -40,9 +49,13 @@ export default function AvatarMenuDemo() {
           />
           <AvatarFallback>ST</AvatarFallback>
         </Avatar>
-        <button className="group relative flex size-12 items-center justify-center rounded-full bg-primary-background text-primary-foreground transition-colors hover:bg-primary hover:text-white">
+        <Button
+          type="button"
+          variant="ghost"
+          className="group relative flex size-12 min-h-12 min-w-12 items-center justify-center rounded-full border-0 bg-primary-background p-0 text-primary-foreground shadow-none transition-colors hover:bg-primary hover:text-white"
+        >
           <span className="text-1xl font-semibold">+3</span>
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/app/content/ui/card-horizontal-detail.tsx
+++ b/src/app/content/ui/card-horizontal-detail.tsx
@@ -5,6 +5,7 @@ import {
 } from "@mdi/js";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardAction,
@@ -119,28 +120,32 @@ function HorizontalDetailCard({
                   className="size-3.5"
                 />
               </span>
-              <button
+              <Button
                 type="button"
-                className="rounded p-0.5 hover:bg-muted"
+                variant="ghost"
+                className="h-auto! min-h-0! w-auto! min-w-0! max-w-min! gap-0! rounded! p-0 shadow-none hover:bg-muted"
+                size="icon-xs"
                 aria-label="More options"
               >
                 <Icon
                   path={mdiDotsHorizontal}
-                  size={1.3}
+                  size={0.9}
                   className="size-3.5 text-neutral-fg"
                 />
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
-                className="absolute right-3 top-1/2 -translate-y-1/2 rounded p-0.5 hover:bg-muted"
+                variant="ghost"
+                size="icon-xs"
+                className="absolute right-3 top-1/2 -translate-y-1/2 rounded p-0 hover:bg-muted"
                 aria-label="Close"
               >
                 <Icon
                   path={mdiClose}
-                  size={1.3}
+                  size={0.9}
                   className="size-3.5 text-neutral-fg"
                 />
-              </button>
+              </Button>
             </CardAction>
           </CardHeader>
           {defaults.showFileType && (

--- a/src/app/content/ui/card-horizontal-normal.tsx
+++ b/src/app/content/ui/card-horizontal-normal.tsx
@@ -1,5 +1,6 @@
 import { mdiCloudCheckVariantOutline, mdiDotsHorizontal } from "@mdi/js";
 
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 import { Icon } from "@/lib/icon";
 
@@ -90,17 +91,19 @@ function HorizontalNormalCard({
                   className="size-3.5"
                 />
               </span>
-              <button
+              <Button
                 type="button"
-                className="rounded p-0.5 hover:bg-muted"
+                variant="ghost"
+                size="icon-xs"
+                className="h-auto! min-h-0! w-auto! min-w-0! max-w-min! gap-0! rounded! p-0 shadow-none hover:bg-muted"
                 aria-label="More options"
               >
                 <Icon
                   path={mdiDotsHorizontal}
-                  size={1.3}
+                  size={0.9}
                   className="size-3.5 text-neutral-fg"
                 />
-              </button>
+              </Button>
             </div>
           </div>
         </CardContent>

--- a/src/app/content/ui/card-styled.tsx
+++ b/src/app/content/ui/card-styled.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Icon } from "@/lib/icon";
 import {
+  mdiDotsHorizontal,
   mdiImageOutline,
   mdiLightbulbOutline,
   mdiPackageVariant,
@@ -23,8 +24,18 @@ export default function CardStyledDemo() {
           <span className="text-sm font-semibold text-muted-foreground wrap-break-word">
             View all briefs
           </span>
-          <Button variant="ghost" size="icon-sm" aria-label="More options">
-            …
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-auto! min-h-0! w-auto! min-w-0! max-w-min! gap-0! rounded! p-0 text-md shadow-none hover:bg-muted"
+            size="icon-xs"
+            aria-label="More options"
+          >
+            <Icon
+              path={mdiDotsHorizontal}
+              size={0.9}
+              className="size-3.5 text-neutral-fg"
+            />
           </Button>
         </div>
       </CardHeader>

--- a/src/app/content/ui/card-vertical-medium.tsx
+++ b/src/app/content/ui/card-vertical-medium.tsx
@@ -5,6 +5,7 @@ import {
 } from "@mdi/js";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardAction,
@@ -93,13 +94,15 @@ function VerticalMediumCard({
             </div>
           )}
           {defaults.showClose && (
-            <button
+            <Button
               type="button"
-              className="absolute right-3 top-3 flex size-8 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/70"
+              variant="ghost"
+              size="icon-sm"
+              className="absolute right-3 top-3 size-8 rounded-full border-0 bg-black/60 p-0 text-white shadow-none transition-none hover:!bg-black/60 hover:!text-white active:!bg-black/60"
               aria-label="Close"
             >
-              <Icon path={mdiClose} size={0.9} className="size-4" />
-            </button>
+              <Icon path={mdiClose} size={0.6} className="size-4" />
+            </Button>
           )}
           {defaults.showFileType && (
             <Badge
@@ -128,17 +131,19 @@ function VerticalMediumCard({
                 className="size-4"
               />
             </span>
-            <button
+            <Button
               type="button"
-              className="rounded p-0.5 hover:bg-muted"
+              variant="ghost"
+              className="h-auto! min-h-0! w-auto! min-w-0! max-w-min! gap-0! rounded! p-0 shadow-none hover:bg-muted"
+              size="icon-xs"
               aria-label="More options"
             >
               <Icon
                 path={mdiDotsHorizontal}
-                size={1.2}
-                className="size-4 text-neutral-fg"
+                size={0.9}
+                className="size-3.5 text-neutral-fg"
               />
-            </button>
+            </Button>
           </CardAction>
         </CardHeader>
       </CardContent>

--- a/src/app/content/ui/card-vertical-small.tsx
+++ b/src/app/content/ui/card-vertical-small.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Icon } from "@/lib/icon";
@@ -81,17 +82,19 @@ function VerticalSmallCard({
         <span className="truncate text-sm font-semibold text-foreground">
           Lorem ipsum
         </span>
-        <button
+        <Button
           type="button"
-          className="shrink-0 rounded p-0.5 hover:bg-muted"
+          variant="ghost"
+          className="h-auto! min-h-0! w-auto! min-w-0! max-w-min! shrink-0! gap-0! rounded! p-0 shadow-none hover:bg-muted"
+          size="icon-xs"
           aria-label="More options"
         >
           <Icon
             path={mdiDotsHorizontal}
-            size={0.9}
+            size={0.7}
             className="size-4 text-neutral-fg"
           />
-        </button>
+        </Button>
       </CardContent>
     </Card>
   );

--- a/src/app/content/ui/card-vertical.tsx
+++ b/src/app/content/ui/card-vertical.tsx
@@ -5,6 +5,7 @@ import {
 } from "@mdi/js";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardAction,
@@ -112,13 +113,15 @@ export function VerticalCard({
             </div>
           )}
           {close && (
-            <button
+            <Button
               type="button"
-              className="absolute right-3 top-3 flex size-8 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/70"
+              variant="ghost"
+              size="icon-sm"
+              className="absolute right-3 top-3 size-8 rounded-full border-0 bg-black/60 p-0 text-white shadow-none transition-none hover:!bg-black/60 hover:!text-white active:!bg-black/60"
               aria-label="Close"
             >
-              <Icon path={mdiClose} size={0.9} className="size-4" />
-            </button>
+              <Icon path={mdiClose} size={0.6} className="size-4" />
+            </Button>
           )}
           {fileType && (
             <Badge
@@ -148,17 +151,19 @@ export function VerticalCard({
                 className="size-4 "
               />
             </span>
-            <button
+            <Button
               type="button"
-              className="rounded p-0.5 hover:bg-muted"
+              variant="ghost"
+              className="h-auto! min-h-0! w-auto! min-w-0! max-w-min! gap-0! rounded! p-0 shadow-none hover:bg-muted"
+              size="icon-xs"
               aria-label="More options"
             >
               <Icon
                 path={mdiDotsHorizontal}
-                size={1.2}
-                className="size-4 text-neutral-fg"
+                size={0.9}
+                className="size-3.5 text-neutral-fg"
               />
-            </button>
+            </Button>
           </CardAction>
         </CardHeader>
         <CardDescription className="-mt-3 text-xs text-muted-foreground line-clamp-2">

--- a/src/app/content/ui/combobox-auto-highlight.tsx
+++ b/src/app/content/ui/combobox-auto-highlight.tsx
@@ -20,7 +20,11 @@ const frameworks = [
 export default function ComboboxAutoHighlightDemo() {
   return (
     <Combobox items={frameworks} autoHighlight>
-      <ComboboxInput placeholder="Select a framework" clear-aria-label="Clear combobox" aria-label="Select a framework" />
+      <ComboboxInput
+        placeholder="Select a framework"
+        clear-aria-label="Clear combobox"
+        aria-label="Select a framework"
+      />
       <ComboboxContent>
         <ComboboxEmpty>No items found.</ComboboxEmpty>
         <ComboboxList>

--- a/src/app/content/ui/combobox-clear-button.tsx
+++ b/src/app/content/ui/combobox-clear-button.tsx
@@ -20,7 +20,12 @@ const frameworks = [
 export default function ComboboxWithClearDemo() {
   return (
     <Combobox items={frameworks} defaultValue={frameworks[0]}>
-      <ComboboxInput placeholder="Select a framework" showClear clear-aria-label="Clear combobox" aria-label="Select a framework" />
+      <ComboboxInput
+        placeholder="Select a framework"
+        showClear
+        clear-aria-label="Clear combobox"
+        aria-label="Select a framework"
+      />
       <ComboboxContent>
         <ComboboxEmpty>No items found.</ComboboxEmpty>
         <ComboboxList>

--- a/src/app/content/ui/combobox-custom-items.tsx
+++ b/src/app/content/ui/combobox-custom-items.tsx
@@ -68,7 +68,11 @@ export default function ComboboxWithCustomItemsDemo() {
       items={countries.filter((country) => country.code !== "")}
       itemToStringValue={(country: (typeof countries)[number]) => country.label}
     >
-      <ComboboxInput placeholder="Search countries..." clear-aria-label="Clear combobox" aria-label="Search countries..." />
+      <ComboboxInput
+        placeholder="Search countries..."
+        clear-aria-label="Clear combobox"
+        aria-label="Search countries..."
+      />
       <ComboboxContent>
         <ComboboxEmpty>No countries found.</ComboboxEmpty>
         <ComboboxList>

--- a/src/app/content/ui/combobox-groups.tsx
+++ b/src/app/content/ui/combobox-groups.tsx
@@ -52,7 +52,11 @@ const timezones = [
 export default function ComboboxWithGroupsAndSeparatorDemo() {
   return (
     <Combobox items={timezones}>
-      <ComboboxInput placeholder="Select a timezone" clear-aria-label="Clear combobox" aria-label="Select a timezone" />
+      <ComboboxInput
+        placeholder="Select a timezone"
+        clear-aria-label="Clear combobox"
+        aria-label="Select a timezone"
+      />
       <ComboboxContent>
         <ComboboxEmpty>No timezones found.</ComboboxEmpty>
         <ComboboxList>

--- a/src/app/content/ui/combobox-input-group.tsx
+++ b/src/app/content/ui/combobox-input-group.tsx
@@ -53,7 +53,11 @@ const timezones = [
 export default function ComboxboxInputGroupDemo() {
   return (
     <Combobox items={timezones}>
-      <ComboboxInput placeholder="Select a timezone" clear-aria-label="Clear combobox" aria-label="Select a timezone">
+      <ComboboxInput
+        placeholder="Select a timezone"
+        clear-aria-label="Clear combobox"
+        aria-label="Select a timezone"
+      >
         <InputGroupAddon>
           <GlobeIcon />
         </InputGroupAddon>

--- a/src/app/content/ui/combobox-multiple.tsx
+++ b/src/app/content/ui/combobox-multiple.tsx
@@ -32,12 +32,18 @@ export default function ComboboxMultipleDemo() {
       items={frameworks}
       defaultValue={[frameworks[0]]}
     >
-      <ComboboxChips ref={anchor} className="w-full max-w-xs" aria-label="Combobox chips">
+      <ComboboxChips
+        ref={anchor}
+        className="w-full max-w-xs"
+        aria-label="Combobox chips"
+      >
         <ComboboxValue>
           {(values: readonly string[]) => (
             <React.Fragment>
               {values.map((value: string) => (
-                <ComboboxChip key={value} aria-label="Remove chip">{value}</ComboboxChip>
+                <ComboboxChip key={value} aria-label="Remove chip">
+                  {value}
+                </ComboboxChip>
               ))}
               <ComboboxChipsInput />
             </React.Fragment>

--- a/src/app/content/ui/combobox-with-description.tsx
+++ b/src/app/content/ui/combobox-with-description.tsx
@@ -81,7 +81,12 @@ export default function ComboboxWithDescriptionDemo() {
           items={itemsAuthoring}
           itemToStringValue={(item: ProductItem) => item.label}
         >
-          <ComboboxInput placeholder="XM Cloud Authoring" className="w-72" clear-aria-label="Clear combobox" aria-label="XM Cloud Authoring" />
+          <ComboboxInput
+            placeholder="XM Cloud Authoring"
+            className="w-72"
+            clear-aria-label="Clear combobox"
+            aria-label="XM Cloud Authoring"
+          />
           <ComboboxContent className="min-w-[22rem]">
             <ComboboxEmpty>No results found.</ComboboxEmpty>
             <ComboboxList>
@@ -105,7 +110,12 @@ export default function ComboboxWithDescriptionDemo() {
           items={itemsPlatform}
           itemToStringValue={(item: ProductItem) => item.label}
         >
-          <ComboboxInput placeholder="Platform & Data" className="w-72" clear-aria-label="Clear combobox" aria-label="Platform & Data" />
+          <ComboboxInput
+            placeholder="Platform & Data"
+            className="w-72"
+            clear-aria-label="Clear combobox"
+            aria-label="Platform & Data"
+          />
           <ComboboxContent className="min-w-[22rem]">
             <ComboboxEmpty>No results found.</ComboboxEmpty>
             <ComboboxList>

--- a/src/app/content/ui/combobox.tsx
+++ b/src/app/content/ui/combobox.tsx
@@ -20,7 +20,11 @@ const frameworks = [
 export default function ComboboxDemo() {
   return (
     <Combobox items={frameworks}>
-      <ComboboxInput placeholder="Select a framework" clear-aria-label="Clear combobox" aria-label="Select a framework" />
+      <ComboboxInput
+        placeholder="Select a framework"
+        clear-aria-label="Clear combobox"
+        aria-label="Select a framework"
+      />
       <ComboboxContent>
         <ComboboxEmpty>No items found.</ComboboxEmpty>
         <ComboboxList>

--- a/src/app/content/ui/field-input-types.tsx
+++ b/src/app/content/ui/field-input-types.tsx
@@ -31,7 +31,9 @@ export default function FieldInputTypesDemo() {
             </FieldDescription>
           </Field>
           <Field>
-            <FieldLabel htmlFor="field-date-range">Date Range Picker</FieldLabel>
+            <FieldLabel htmlFor="field-date-range">
+              Date Range Picker
+            </FieldLabel>
             <DatePickerWithRange id="field-date-range" />
             <FieldDescription>
               Select a date range using the Blok date picker.
@@ -51,7 +53,12 @@ export default function FieldInputTypesDemo() {
           </Field>
           <Field>
             <FieldLabel htmlFor="field-number">Input number</FieldLabel>
-            <Input id="field-number" type="number" autoComplete="off" placeholder="Enter number" />
+            <Input
+              id="field-number"
+              type="number"
+              autoComplete="off"
+              placeholder="Enter number"
+            />
           </Field>
           <Field>
             <FieldLabel htmlFor="field-search">Input search</FieldLabel>
@@ -59,7 +66,13 @@ export default function FieldInputTypesDemo() {
           </Field>
           <Field>
             <FieldLabel htmlFor="field-tel">Input tel</FieldLabel>
-            <Input id="field-tel" type="tel" name="tel" autoComplete="tel" placeholder="Enter phone number" />
+            <Input
+              id="field-tel"
+              type="tel"
+              name="tel"
+              autoComplete="tel"
+              placeholder="Enter phone number"
+            />
           </Field>
           <Field>
             <FieldLabel htmlFor="field-time">Time Picker</FieldLabel>

--- a/src/app/content/ui/field-input.tsx
+++ b/src/app/content/ui/field-input.tsx
@@ -16,7 +16,12 @@ export default function FieldInputDemo() {
         <FieldGroup>
           <Field>
             <FieldLabel htmlFor="field-input-username">Username</FieldLabel>
-            <Input id="field-input-username" name="username" autoComplete="username" placeholder="Enter username" />
+            <Input
+              id="field-input-username"
+              name="username"
+              autoComplete="username"
+              placeholder="Enter username"
+            />
             <FieldDescription>
               Choose a unique username for your account.
             </FieldDescription>

--- a/src/app/content/ui/field-radio-group.tsx
+++ b/src/app/content/ui/field-radio-group.tsx
@@ -15,7 +15,9 @@ export default function FieldRadioGroupDemo() {
         <FieldLegend>Payment Method</FieldLegend>
         <FieldGroup>
           <Field>
-            <FieldLabel htmlFor="field-radio-group">Select payment method</FieldLabel>
+            <FieldLabel htmlFor="field-radio-group">
+              Select payment method
+            </FieldLabel>
             <RadioGroup defaultValue="card" id="field-radio-group">
               <Field orientation="horizontal">
                 <RadioGroupItem value="card" id="field-radio-card" />

--- a/src/app/content/ui/field-separator.tsx
+++ b/src/app/content/ui/field-separator.tsx
@@ -17,11 +17,21 @@ export default function FieldWithSeparatorDemo() {
           <FieldGroup>
             <Field>
               <FieldLabel htmlFor="field-sep-first">First name</FieldLabel>
-              <Input id="field-sep-first" name="given-name" autoComplete="given-name" placeholder="John" />
+              <Input
+                id="field-sep-first"
+                name="given-name"
+                autoComplete="given-name"
+                placeholder="John"
+              />
             </Field>
             <Field>
               <FieldLabel htmlFor="field-sep-last">Last name</FieldLabel>
-              <Input id="field-sep-last" name="family-name" autoComplete="family-name" placeholder="Doe" />
+              <Input
+                id="field-sep-last"
+                name="family-name"
+                autoComplete="family-name"
+                placeholder="Doe"
+              />
             </Field>
           </FieldGroup>
         </FieldSet>

--- a/src/app/content/ui/field.tsx
+++ b/src/app/content/ui/field.tsx
@@ -21,14 +21,24 @@ export default function FieldDemo() {
         <FieldGroup>
           <Field orientation="responsive">
             <FieldLabel htmlFor="field-name">Full name</FieldLabel>
-            <Input id="field-name" name="name" autoComplete="name" placeholder="Vijithan Ramalingam" />
+            <Input
+              id="field-name"
+              name="name"
+              autoComplete="name"
+              placeholder="Vijithan Ramalingam"
+            />
             <FieldDescription>
               This appears on invoices and emails.
             </FieldDescription>
           </Field>
           <Field>
             <FieldLabel htmlFor="field-username">Username</FieldLabel>
-            <Input id="field-username" name="username" autoComplete="username" aria-invalid />
+            <Input
+              id="field-username"
+              name="username"
+              autoComplete="username"
+              aria-invalid
+            />
             <FieldError>Choose another username.</FieldError>
           </Field>
           <Field orientation="horizontal">

--- a/src/app/content/ui/input-group-dropdown.tsx
+++ b/src/app/content/ui/input-group-dropdown.tsx
@@ -17,7 +17,11 @@ export default function InputGroupDropdownDemo() {
   return (
     <div className="grid w-full max-w-md gap-4">
       <InputGroup>
-        <InputGroupInput autoComplete="off" placeholder="Enter file name" aria-label="File name" />
+        <InputGroupInput
+          autoComplete="off"
+          placeholder="Enter file name"
+          aria-label="File name"
+        />
         <InputGroupAddon align="inline-end">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/app/content/ui/input-group.tsx
+++ b/src/app/content/ui/input-group.tsx
@@ -41,7 +41,11 @@ export default function InputGroupDemo() {
         <InputGroupAddon align="inline-end">
           <Tooltip>
             <TooltipTrigger asChild>
-              <InputGroupButton className="rounded-full" size="icon-xs" aria-label="Information">
+              <InputGroupButton
+                className="rounded-full"
+                size="icon-xs"
+                aria-label="Information"
+              >
                 <Icon path={mdiInformationOutline} size={0.9} />
               </InputGroupButton>
             </TooltipTrigger>
@@ -51,7 +55,11 @@ export default function InputGroupDemo() {
       </InputGroup>
       {/* Dropdown */}
       <InputGroup>
-        <InputGroupInput autoComplete="off" placeholder="Enter file name" aria-label="File name" />
+        <InputGroupInput
+          autoComplete="off"
+          placeholder="Enter file name"
+          aria-label="File name"
+        />
         <InputGroupAddon align="inline-end">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/src/components/bloks/collaboration.tsx
+++ b/src/components/bloks/collaboration.tsx
@@ -285,7 +285,7 @@ export function Collaboration<T extends User = User>({
           <Button
             type="button"
             variant="ghost"
-            className="h-auto min-h-0 w-fit rounded-full p-0 focus-visible:ring-2 focus-visible:ring-primary"
+            className="h-auto min-h-0 w-fit rounded-full p-0 bg-transparent hover:bg-transparent active:bg-transparent focus-visible:ring-2 focus-visible:ring-primary"
           >
             <AvatarTrigger users={users} maxDisplay={maxDisplayAvatars} />
           </Button>

--- a/src/components/bloks/collaboration.tsx
+++ b/src/components/bloks/collaboration.tsx
@@ -282,9 +282,13 @@ export function Collaboration<T extends User = User>({
       {/* First Popover: Avatar -> Users Card */}
       <Popover open={isUsersOpen} onOpenChange={handleUsersOpenChange}>
         <PopoverTrigger asChild>
-          <button className="focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-full">
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-auto min-h-0 w-fit rounded-full p-0 focus-visible:ring-2 focus-visible:ring-primary"
+          >
             <AvatarTrigger users={users} maxDisplay={maxDisplayAvatars} />
-          </button>
+          </Button>
         </PopoverTrigger>
 
         <PopoverContent

--- a/src/components/bloks/pinned-sites-section.tsx
+++ b/src/components/bloks/pinned-sites-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { SiteCard } from "@/components/bloks/site-card";
+import { Button } from "@/components/ui/button";
 import EmptyPin from "@/lib/empty-pin.svg";
 import type { ComponentProps } from "react";
 
@@ -109,9 +110,9 @@ export function PinnedSitesSection<T extends SiteData>({
               Pin the sites you work on most to keep them front and center,
               making it easier to switch, manage, and stay productive
             </p>
-            <button className="text-sm font-semibold text-primary hover:underline">
+            <Button variant="link" className="text-sm font-semibold">
               Start pinning sites
-            </button>
+            </Button>
           </div>
         )}
       </section>

--- a/src/components/docsite/docsite-sidebar.tsx
+++ b/src/components/docsite/docsite-sidebar.tsx
@@ -286,7 +286,9 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
+    <Button
+      type="button"
+      variant="ghost"
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"
@@ -294,7 +296,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex",
+        "!h-full !min-h-0 !min-w-0 w-4 rounded-none px-0 hover:bg-transparent -translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full",

--- a/src/components/layout/right-sidebar.tsx
+++ b/src/components/layout/right-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "@/components/ui/button";
 import { TELEMETRY_EVENTS, track } from "@/lib/telemetry";
 import { cn } from "@/lib/utils";
 import { mdiOpenInNew } from "@mdi/js";
@@ -45,6 +46,17 @@ function buildPageContext(pageName?: string, pageType?: PageType) {
     ...(pageType === "primitive" && { component_name: pageName }),
     ...(pageType === "blok" && { block_name: pageName }),
   };
+}
+
+/** Neutralize default `Button` */
+function tocNavButtonClassName(isActive: boolean) {
+  return cn(
+    "h-auto min-h-0 w-full min-w-0 justify-start gap-0 rounded-none border-0 bg-transparent px-0 py-0 my-0 text-start text-md font-semibold shadow-none",
+    "hover:bg-transparent hover:text-foreground active:bg-transparent",
+    "focus-visible:ring-0",
+    "transition-colors",
+    isActive ? "text-foreground" : "text-muted-foreground",
+  );
 }
 
 export function RightSidebar({
@@ -272,34 +284,28 @@ export function RightSidebar({
           <ul className="space-y-2">
             {sections.map((section) => (
               <li key={section.id}>
-                <button
+                <Button
                   type="button"
+                  variant="ghost"
                   onClick={() => scrollToSection(section.id, section.title)}
-                  className={cn(
-                    "block w-full text-start text-md font-semibold transition-colors hover:text-foreground",
-                    activeId === section.id
-                      ? "text-foreground"
-                      : "text-muted-foreground",
-                  )}
+                  className={tocNavButtonClassName(activeId === section.id)}
                 >
                   {section.title}
-                </button>
+                </Button>
                 {section.children && (
                   <ul className="mt-2 space-y-2 ps-4">
                     {section.children.map((child) => (
                       <li key={child.id}>
-                        <button
+                        <Button
                           type="button"
+                          variant="ghost"
                           onClick={() => scrollToSection(child.id, child.title)}
-                          className={cn(
-                            "block w-full text-start text-md font-semibold transition-colors hover:text-foreground",
-                            activeId === child.id
-                              ? "text-foreground"
-                              : "text-muted-foreground",
+                          className={tocNavButtonClassName(
+                            activeId === child.id,
                           )}
                         >
                           {child.title}
-                        </button>
+                        </Button>
                       </li>
                     ))}
                   </ul>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -39,7 +39,11 @@ function ComboboxTrigger({
   );
 }
 
-function ComboboxClear({ className, "aria-label": ariaLabel, ...props }: ComboboxPrimitive.Clear.Props) {
+function ComboboxClear({
+  className,
+  "aria-label": ariaLabel,
+  ...props
+}: ComboboxPrimitive.Clear.Props) {
   return (
     <ComboboxPrimitive.Clear
       data-slot="combobox-clear"
@@ -97,7 +101,9 @@ function ComboboxInput({
             <ComboboxTrigger />
           </InputGroupButton>
         )}
-        {showClear && <ComboboxClear disabled={disabled} aria-label={clearAriaLabel} />}
+        {showClear && (
+          <ComboboxClear disabled={disabled} aria-label={clearAriaLabel} />
+        )}
       </InputGroupAddon>
       {children}
     </InputGroup>

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -385,9 +385,10 @@ const FilterSingleSelect = React.forwardRef<
               }}
             >
               <PopoverTrigger asChild>
-                <button
+                <Button
                   ref={ref}
                   type="button"
+                  variant="ghost"
                   aria-label={ariaLabel}
                   aria-describedby={describedBy}
                   aria-expanded={open}
@@ -436,7 +437,7 @@ const FilterSingleSelect = React.forwardRef<
                       className="size-4 shrink-0 pointer-events-none text-current"
                     />
                   )}
-                </button>
+                </Button>
               </PopoverTrigger>
               <PopoverContent
                 align="start"
@@ -487,15 +488,16 @@ const FilterSingleSelect = React.forwardRef<
                       </div>
                     ) : (
                       filteredOptions.map((option) => (
-                        <button
+                        <Button
                           key={option.value}
                           type="button"
+                          variant="ghost"
                           role="option"
                           aria-selected={value === option.value}
                           disabled={option.disabled}
                           onClick={() => handleChange(option.value)}
                           className={cn(
-                            "flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1 text-left text-sm outline-none hover:bg-accent/50 focus:bg-accent/50",
+                            "h-auto min-h-0 w-full justify-between rounded-sm px-2 py-1 text-left text-sm font-normal hover:bg-accent/50 focus-visible:bg-accent/50",
                             option.disabled &&
                               "opacity-50 cursor-not-allowed pointer-events-none",
                           )}
@@ -510,7 +512,7 @@ const FilterSingleSelect = React.forwardRef<
                               className="size-4 shrink-0 text-primary-fg"
                             />
                           )}
-                        </button>
+                        </Button>
                       ))
                     )}
                   </div>
@@ -852,9 +854,10 @@ const FilterMultiSelect = React.forwardRef<
         >
           <Popover open={open} onOpenChange={handleOpenChangeWithSearch}>
             <PopoverTrigger asChild>
-              <button
+              <Button
                 ref={setButtonRef}
                 type="button"
+                variant="ghost"
                 disabled={disabled}
                 aria-describedby={describedBy}
                 aria-expanded={open}
@@ -999,7 +1002,7 @@ const FilterMultiSelect = React.forwardRef<
                     className="size-4 shrink-0 pointer-events-none text-current"
                   />
                 )}
-              </button>
+              </Button>
             </PopoverTrigger>
             <PopoverContent
               className={cn(

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -285,7 +285,9 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
+    <Button
+      type="button"
+      variant="ghost"
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"
@@ -293,7 +295,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "h-full! min-h-0! min-w-0! w-4 rounded-none px-0 hover:bg-transparent absolute inset-y-0 z-20 hidden -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",

--- a/src/marketplace/react/components/examples/with-xmc/list-languages.tsx
+++ b/src/marketplace/react/components/examples/with-xmc/list-languages.tsx
@@ -37,7 +37,9 @@ export const ListLanguagesFromClientSdk = () => {
   return (
     <div>
       <h1>Client API Request</h1>
-      <button onClick={fetchLanguages}>Fetch Languages</button>
+      <button type="button" onClick={fetchLanguages}>
+        Fetch Languages
+      </button>
       <div>Languages: {languages.length}</div>
       <div>{languages.map((language) => language.name)}</div>
     </div>


### PR DESCRIPTION
### Primitives & Layout

* **Filter**: Popover triggers and options now use `Button` (`ghost` variant) to match previous styling.
* **Sidebar**: `SidebarRail` updated to use `Button` with layout tweaks for consistent click area.
* **Right Sidebar**: TOC items use `Button` with a shared helper for full-width, flat text styling.
* **Docsite Sidebar**: `SidebarRail` aligned with the same sidebar pattern.
* **Avatar Menu**: All controls now use `Button`.

### Bloks 

* Collaboration: Avatar stack popover trigger now uses `Button`.
* Pinned sites empty state uses `Button` (`link` variant).

### Demo Updates

* **Cards (all variants)**:

  * Kebab & close actions use `Button`.
  * Fixed oversized icons in compact menus.
  * Unified overlay close buttons (same size, styles).

* **Sidebar RHS Demos**:
  * Actions like read more, copy, reply, menu → all use `Button`.

### Graphics Pages
* **Logos Page**: Logo cells use `Button` with style overrides.
* **Icons Page**: Icons centered properly under headers (including loading states).

### Exclusion

* `list-languages.tsx` remains using native `<button>` due to TypeScript `rootDir` restriction (avoids build errors).
