### PR TITLE
Prompt input Blok Implementation

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -1819,6 +1819,27 @@
           "target": "src/components/bloks/sidebar-rhs.tsx"
         }
       ]
+    },
+    {
+      "name": "prompt-input",
+      "type": "registry:block",
+      "title": "Prompt input",
+      "description": "A composable prompt input for AI chat and in-page editing experiences. Includes auto-resizing textarea, file attachments, and action toolbar. Available in Default (chatbot) and Floating (canvas/in-page) variants.",
+      "registryDependencies": [
+        "https://blok.sitecore.com/r/theme.json",
+        "https://blok.sitecore.com/r/badge.json",
+        "https://blok.sitecore.com/r/button.json",
+        "https://blok.sitecore.com/r/tooltip.json",
+        "https://blok.sitecore.com/r/popover.json"
+      ],
+      "dependencies": ["@mdi/js"],
+      "files": [
+        {
+          "path": "src/components/bloks/prompt-input.tsx",
+          "type": "registry:block",
+          "target": "src/components/bloks/prompt-input.tsx"
+        }
+      ]
     }
   ]
 }

--- a/registries/registry.json
+++ b/registries/registry.json
@@ -1830,7 +1830,8 @@
         "https://blok.sitecore.com/r/badge.json",
         "https://blok.sitecore.com/r/button.json",
         "https://blok.sitecore.com/r/tooltip.json",
-        "https://blok.sitecore.com/r/popover.json"
+        "https://blok.sitecore.com/r/popover.json",
+        "https://blok.sitecore.com/r/textarea.json"
       ],
       "dependencies": ["@mdi/js"],
       "files": [

--- a/src/app/content/bloks/prompt-input-floating.tsx
+++ b/src/app/content/bloks/prompt-input-floating.tsx
@@ -15,41 +15,129 @@ import {
   PromptInputTextarea,
   PromptInputToolbar,
 } from "@/components/bloks/prompt-input";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import { mdiChevronDown } from "@mdi/js";
 import { useState } from "react";
 
-export default function PromptInputFloatingDemo() {
-  const [lastMessage, setLastMessage] = useState<string>("");
+const COLUMN_WIDTH_PX = 576;
+
+type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+};
+
+const initialMessages: ChatMessage[] = [
+  {
+    id: "1",
+    role: "user",
+    text: "Edit this image to be more warm in tone",
+  },
+  {
+    id: "2",
+    role: "assistant",
+    text: "Sure thing!\nI will now edit this image to be more warm in tone!",
+  },
+  {
+    id: "3",
+    role: "user",
+    text: "Can you replace the font with something Serif?",
+  },
+  {
+    id: "4",
+    role: "assistant",
+    text: "Of course! I will now replace the font with the Serif font \u2018Georgia\u2019.",
+  },
+];
+
+function FloatingChatCard() {
+  const [, setLastMessage] = useState<string>("");
 
   const handleSubmit = (message: PromptInputMessage) => {
     setLastMessage(message.text);
   };
 
   return (
-    <div className="relative flex flex-col items-center justify-end gap-4 p-8 min-h-[400px] w-full bg-muted/30 rounded-lg">
-      <div className="flex-1 flex items-center justify-center">
-        <p className="text-sm text-muted-foreground">
-          {lastMessage
-            ? `You said: "${lastMessage}"`
-            : "Canvas / page content area"}
-        </p>
-      </div>
+    <div
+      className={cn(
+        "flex min-w-0 max-w-full flex-col rounded-xl border bg-white shadow-lg",
+        "dark:bg-input/30",
+      )}
+      style={{ width: `${COLUMN_WIDTH_PX}px` }}
+    >
+      <Collapsible className="w-full min-w-0" defaultOpen>
+        <CollapsibleTrigger
+          className={cn(
+            "grid w-full grid-cols-[1rem_minmax(0,1fr)] items-center gap-x-3 px-4 py-3 text-left text-sm font-semibold text-foreground outline-none",
+            "hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset",
+            "[&[data-state=open]>svg:first-child]:rotate-0 [&[data-state=closed]>svg:first-child]:-rotate-90",
+          )}
+        >
+          <Icon
+            path={mdiChevronDown}
+            className="size-4 shrink-0 justify-self-center text-muted-foreground transition-transform duration-200"
+            aria-hidden
+          />
+          <span className="min-w-0">Chat</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="overflow-hidden">
+          <ul className="flex flex-col gap-3 px-4 pb-4">
+            {initialMessages.map((message) => (
+              <li
+                key={message.id}
+                className={cn(
+                  "flex min-w-0",
+                  message.role === "user" ? "justify-end" : "justify-start",
+                )}
+              >
+                {message.role === "user" ? (
+                  <div className="max-w-[80%] whitespace-pre-line rounded-md bg-muted px-3 py-2 text-sm text-foreground">
+                    {message.text}
+                  </div>
+                ) : (
+                  <p className="max-w-[90%] whitespace-pre-line text-sm text-foreground">
+                    {message.text}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </CollapsibleContent>
+      </Collapsible>
+
       <PromptInput
         variant="floating"
         onSubmit={handleSubmit}
-        className="w-full max-w-xl"
+        style={{
+          minWidth: 0,
+          width: "calc(100% + 2px)",
+          maxWidth: "calc(100% + 2px)",
+          marginLeft: "-1px",
+          marginRight: "-1px",
+          marginBottom: "-1px",
+        }}
+        className={cn(
+          "rounded-b-xl rounded-t-lg border bg-white shadow-none",
+          "focus-within:border-border focus-within:ring-0",
+          "dark:bg-input/30",
+        )}
       >
         <PromptInputHeader>
           <PromptInputAttachments />
         </PromptInputHeader>
-        {/* Visible only when single-line (inline layout) */}
         <PromptInputToolbar inline>
           <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
         </PromptInputToolbar>
         <PromptInputBody>
-          <PromptInputTextarea placeholder="Edit this page…" />
+          <PromptInputTextarea placeholder="/ for tools, @ for context references" />
         </PromptInputBody>
         <PromptInputFooter>
-          {/* Visible only when multiline (column layout) */}
           <PromptInputToolbar>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
           </PromptInputToolbar>
@@ -59,6 +147,58 @@ export default function PromptInputFloatingDemo() {
           </PromptInputActions>
         </PromptInputFooter>
       </PromptInput>
+    </div>
+  );
+}
+
+export default function PromptInputFloatingDemo() {
+  const [lastMessage, setLastMessage] = useState<string>("");
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    setLastMessage(message.text);
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-3 p-8">
+      <div className="relative flex min-h-[400px] w-full flex-col items-center justify-end gap-4 rounded-lg bg-muted/30 p-8">
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-sm text-muted-foreground">
+            {lastMessage
+              ? `You said: "${lastMessage}"`
+              : "Canvas / page content area"}
+          </p>
+        </div>
+        <PromptInput
+          variant="floating"
+          onSubmit={handleSubmit}
+          className="w-full max-w-xl"
+        >
+          <PromptInputHeader>
+            <PromptInputAttachments />
+          </PromptInputHeader>
+          {/* Visible only when single-line (inline layout) */}
+          <PromptInputToolbar inline>
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          </PromptInputToolbar>
+          <PromptInputBody>
+            <PromptInputTextarea placeholder="Edit this page…" />
+          </PromptInputBody>
+          <PromptInputFooter>
+            {/* Visible only when multiline (column layout) */}
+            <PromptInputToolbar>
+              <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            </PromptInputToolbar>
+            <PromptInputActions>
+              <PromptInputMicButton />
+              <PromptInputSubmit />
+            </PromptInputActions>
+          </PromptInputFooter>
+        </PromptInput>
+      </div>
+
+      <div className="relative flex min-h-[480px] w-full flex-col items-center justify-end gap-4 rounded-lg bg-muted/30 p-8">
+        <FloatingChatCard />
+      </div>
     </div>
   );
 }

--- a/src/app/content/bloks/prompt-input-floating.tsx
+++ b/src/app/content/bloks/prompt-input-floating.tsx
@@ -1,5 +1,6 @@
 "use client"; // Please remove this if you are not using nextjs
 
+import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
 import {
   PromptInput,
   PromptInputActions,
@@ -42,7 +43,7 @@ export default function PromptInputFloatingDemo() {
         </PromptInputHeader>
         {/* Visible only when single-line (inline layout) */}
         <PromptInputToolbar inline>
-          <PromptInputAttachButton />
+          <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
         </PromptInputToolbar>
         <PromptInputBody>
           <PromptInputTextarea placeholder="Edit this page…" />
@@ -50,7 +51,7 @@ export default function PromptInputFloatingDemo() {
         <PromptInputFooter>
           {/* Visible only when multiline (column layout) */}
           <PromptInputToolbar>
-            <PromptInputAttachButton />
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
           </PromptInputToolbar>
           <PromptInputActions>
             <PromptInputMicButton />

--- a/src/app/content/bloks/prompt-input-floating.tsx
+++ b/src/app/content/bloks/prompt-input-floating.tsx
@@ -1,0 +1,63 @@
+"use client"; // Please remove this if you are not using nextjs
+
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  type PromptInputMessage,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/components/bloks/prompt-input";
+import { useState } from "react";
+
+export default function PromptInputFloatingDemo() {
+  const [lastMessage, setLastMessage] = useState<string>("");
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    setLastMessage(message.text);
+  };
+
+  return (
+    <div className="relative flex flex-col items-center justify-end gap-4 p-8 min-h-[400px] w-full bg-muted/30 rounded-lg">
+      <div className="flex-1 flex items-center justify-center">
+        <p className="text-sm text-muted-foreground">
+          {lastMessage
+            ? `You said: "${lastMessage}"`
+            : "Canvas / page content area"}
+        </p>
+      </div>
+      <PromptInput
+        variant="floating"
+        onSubmit={handleSubmit}
+        className="w-full max-w-xl"
+      >
+        <PromptInputHeader>
+          <PromptInputAttachments />
+        </PromptInputHeader>
+        {/* Visible only when single-line (inline layout) */}
+        <PromptInputToolbar inline>
+          <PromptInputAttachButton />
+        </PromptInputToolbar>
+        <PromptInputBody>
+          <PromptInputTextarea placeholder="Edit this page…" />
+        </PromptInputBody>
+        <PromptInputFooter>
+          {/* Visible only when multiline (column layout) */}
+          <PromptInputToolbar>
+            <PromptInputAttachButton />
+          </PromptInputToolbar>
+          <PromptInputActions>
+            <PromptInputMicButton />
+            <PromptInputSubmit />
+          </PromptInputActions>
+        </PromptInputFooter>
+      </PromptInput>
+    </div>
+  );
+}

--- a/src/app/content/bloks/prompt-input-floating.tsx
+++ b/src/app/content/bloks/prompt-input-floating.tsx
@@ -11,6 +11,7 @@ import {
   PromptInputHeader,
   type PromptInputMessage,
   PromptInputMicButton,
+  PromptInputSelections,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputToolbar,
@@ -133,6 +134,7 @@ function FloatingChatCard() {
         </PromptInputHeader>
         <PromptInputToolbar inline>
           <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          <PromptInputSelections />
         </PromptInputToolbar>
         <PromptInputBody>
           <PromptInputTextarea placeholder="/ for tools, @ for context references" />
@@ -140,6 +142,7 @@ function FloatingChatCard() {
         <PromptInputFooter>
           <PromptInputToolbar>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
             <PromptInputMicButton />
@@ -179,6 +182,7 @@ export default function PromptInputFloatingDemo() {
           {/* Visible only when single-line (inline layout) */}
           <PromptInputToolbar inline>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputBody>
             <PromptInputTextarea placeholder="Edit this page…" />
@@ -187,6 +191,7 @@ export default function PromptInputFloatingDemo() {
             {/* Visible only when multiline (column layout) */}
             <PromptInputToolbar>
               <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+              <PromptInputSelections />
             </PromptInputToolbar>
             <PromptInputActions>
               <PromptInputMicButton />

--- a/src/app/content/bloks/prompt-input-questions.tsx
+++ b/src/app/content/bloks/prompt-input-questions.tsx
@@ -1,0 +1,177 @@
+"use client"; // Please remove this if you are not using nextjs
+
+import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  type PromptInputMessage,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+  type PromptInputVariant,
+} from "@/components/bloks/prompt-input";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+
+const question =
+  "This is the question that is being asked by the AI… or is it?";
+const answers = [
+  { id: "a", label: "This is the first response to the question" },
+  { id: "b", label: "This is the second response to the question" },
+  { id: "c", label: "This is the third response to the question" },
+];
+
+const COLUMN_WIDTH_PX = 576;
+
+interface QuestionPromptCardProps {
+  variant: PromptInputVariant;
+  placeholder: string;
+  /** Optional shadow override; floating uses `shadow-lg`. */
+  shellShadowClass?: string;
+}
+
+function QuestionPromptCard({
+  variant,
+  placeholder,
+  shellShadowClass = "shadow-sm",
+}: QuestionPromptCardProps) {
+  const [, setLastMessage] = useState<string>("");
+  const [selectedId, setSelectedId] = useState<string | null>("a");
+  const [skipped, setSkipped] = useState(false);
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    setLastMessage(message.text);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 max-w-full flex-col rounded-xl border bg-white",
+        "dark:bg-input/30",
+        shellShadowClass,
+      )}
+      style={{ width: `${COLUMN_WIDTH_PX}px` }}
+    >
+      {!skipped && (
+        <div className="flex w-full min-w-0 flex-col gap-3 px-4 pt-3 pb-4">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-semibold text-foreground">
+              Questions
+            </span>
+            <button
+              type="button"
+              onClick={() => setSkipped(true)}
+              className={cn(
+                "rounded-sm text-sm font-medium text-primary outline-none",
+                "hover:underline focus-visible:ring-2 focus-visible:ring-ring/50",
+              )}
+            >
+              Skip
+            </button>
+          </div>
+
+          <p className="text-sm text-foreground">{question}</p>
+
+          <ul
+            role="radiogroup"
+            aria-label="Question answers"
+            className="flex flex-col gap-2"
+          >
+            {answers.map((answer, index) => {
+              const letter = String.fromCharCode(65 + index);
+              const isSelected = selectedId === answer.id;
+              return (
+                <li key={answer.id} className="min-w-0">
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => setSelectedId(answer.id)}
+                    className={cn(
+                      "flex w-full min-w-0 items-center gap-1 rounded-md px-3 py-2.5 text-left text-sm outline-none transition-colors",
+                      "focus-visible:ring-2 focus-visible:ring-ring/50",
+                      isSelected
+                        ? "bg-primary-background text-foreground"
+                        : "bg-muted text-foreground hover:bg-muted/70",
+                    )}
+                  >
+                    <span className="shrink-0">{letter}.</span>
+                    <span className="min-w-0 truncate">{answer.label}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      <PromptInput
+        variant={variant}
+        onSubmit={handleSubmit}
+        style={{
+          minWidth: 0,
+          width: "calc(100% + 2px)",
+          maxWidth: "calc(100% + 2px)",
+          marginLeft: "-1px",
+          marginRight: "-1px",
+          marginBottom: "-1px",
+          marginTop: skipped ? "-1px" : 0,
+        }}
+        className={cn(
+          "border bg-white shadow-none",
+          skipped ? "rounded-xl" : "rounded-b-xl rounded-t-lg",
+          "focus-within:border-border focus-within:ring-0",
+          "dark:bg-input/30",
+        )}
+      >
+        <PromptInputHeader>
+          <PromptInputAttachments />
+        </PromptInputHeader>
+        {variant === "floating" && (
+          <PromptInputToolbar inline>
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          </PromptInputToolbar>
+        )}
+        <PromptInputBody>
+          <PromptInputTextarea placeholder={placeholder} />
+        </PromptInputBody>
+        <PromptInputFooter>
+          <PromptInputToolbar>
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          </PromptInputToolbar>
+          <PromptInputActions>
+            <PromptInputMicButton />
+            <PromptInputSubmit />
+          </PromptInputActions>
+        </PromptInputFooter>
+      </PromptInput>
+    </div>
+  );
+}
+
+export default function PromptInputQuestionsDemo() {
+  return (
+    <div className="flex w-full flex-col gap-3 p-8">
+      <div className="relative flex min-h-[420px] w-full flex-col items-center justify-end p-4">
+        <QuestionPromptCard
+          variant="default"
+          placeholder="Respond to the question"
+        />
+      </div>
+
+      <div className="relative flex min-h-[420px] w-full flex-col items-center justify-end gap-4 rounded-lg bg-muted/30 p-8">
+        <QuestionPromptCard
+          variant="floating"
+          placeholder="Respond to the question"
+          shellShadowClass="shadow-lg"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/content/bloks/prompt-input-questions.tsx
+++ b/src/app/content/bloks/prompt-input-questions.tsx
@@ -11,6 +11,7 @@ import {
   PromptInputHeader,
   type PromptInputMessage,
   PromptInputMicButton,
+  PromptInputSelections,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputToolbar,
@@ -136,6 +137,7 @@ function QuestionPromptCard({
         {variant === "floating" && (
           <PromptInputToolbar inline>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
         )}
         <PromptInputBody>
@@ -144,6 +146,7 @@ function QuestionPromptCard({
         <PromptInputFooter>
           <PromptInputToolbar>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
             <PromptInputMicButton />

--- a/src/app/content/bloks/prompt-input-queued.tsx
+++ b/src/app/content/bloks/prompt-input-queued.tsx
@@ -11,6 +11,7 @@ import {
   PromptInputHeader,
   type PromptInputMessage,
   PromptInputMicButton,
+  PromptInputSelections,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputToolbar,
@@ -124,6 +125,7 @@ function QueuedPromptCard({
         {variant === "floating" && (
           <PromptInputToolbar inline>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
         )}
         <PromptInputBody>
@@ -132,6 +134,7 @@ function QueuedPromptCard({
         <PromptInputFooter>
           <PromptInputToolbar>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
             <PromptInputMicButton />

--- a/src/app/content/bloks/prompt-input-queued.tsx
+++ b/src/app/content/bloks/prompt-input-queued.tsx
@@ -153,7 +153,7 @@ function QueuedPromptCard({
 
 export default function PromptInputQueuedDemo() {
   return (
-    <div className="flex w-full flex-col gap-8 p-8">
+    <div className="flex w-full flex-col gap-3 p-8">
       <div className="relative flex min-h-[420px] w-full flex-col items-center justify-end p-4">
         <QueuedPromptCard variant="default" placeholder="Message..." />
       </div>

--- a/src/app/content/bloks/prompt-input-queued.tsx
+++ b/src/app/content/bloks/prompt-input-queued.tsx
@@ -1,0 +1,170 @@
+"use client"; // Please remove this if you are not using nextjs
+
+import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  type PromptInputMessage,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+  type PromptInputVariant,
+} from "@/components/bloks/prompt-input";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Icon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import { mdiChevronDown, mdiClockOutline } from "@mdi/js";
+import { useState } from "react";
+
+const queuedPrompts = [
+  "Do this thing",
+  "Do the other thing",
+  "Do one more thing",
+  "Let's make it interesting",
+  "Lorem ipsum dolor sit amet consectetur. Neque felis scelerisque proin volutpat purus vel bibendum. Integer faucibus magna at augue sollicitudin.",
+];
+
+const COLUMN_WIDTH_PX = 576;
+
+interface QueuedPromptCardProps {
+  variant: PromptInputVariant;
+  placeholder: string;
+  /** Optional shadow override; floating uses `shadow-lg`. */
+  shellShadowClass?: string;
+}
+
+function QueuedPromptCard({
+  variant,
+  placeholder,
+  shellShadowClass = "shadow-sm",
+}: QueuedPromptCardProps) {
+  const [, setLastMessage] = useState<string>("");
+  const [isProcessing, setIsProcessing] = useState(true);
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    setLastMessage(message.text);
+    setIsProcessing(true);
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 max-w-full flex-col rounded-xl border bg-white",
+        "dark:bg-input/30",
+        shellShadowClass,
+      )}
+      style={{ width: `${COLUMN_WIDTH_PX}px` }}
+    >
+      <Collapsible className="w-full min-w-0" defaultOpen>
+        <CollapsibleTrigger
+          className={cn(
+            "grid w-full grid-cols-[1rem_minmax(0,1fr)] items-center gap-x-3 px-4 py-3 text-left text-sm font-semibold text-foreground outline-none",
+            "hover:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-inset",
+            "[&[data-state=open]>svg:first-child]:rotate-0 [&[data-state=closed]>svg:first-child]:-rotate-90",
+          )}
+        >
+          <Icon
+            path={mdiChevronDown}
+            className="size-4 shrink-0 justify-self-center text-muted-foreground transition-transform duration-200"
+            aria-hidden
+          />
+          <span className="min-w-0">{queuedPrompts.length} prompts queued</span>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="overflow-hidden">
+          <ul className="space-y-2.5 px-4 pb-3">
+            {queuedPrompts.map((text) => (
+              <li
+                key={text}
+                className="grid w-full min-w-0 grid-cols-[1rem_minmax(0,1fr)] items-center gap-x-3"
+              >
+                <Icon
+                  path={mdiClockOutline}
+                  className="size-4 shrink-0 justify-self-center text-muted-foreground"
+                  aria-hidden
+                />
+                <span className="min-w-0 truncate text-sm text-muted-foreground">
+                  {text}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </CollapsibleContent>
+      </Collapsible>
+
+      <PromptInput
+        variant={variant}
+        onSubmit={handleSubmit}
+        style={{
+          minWidth: 0,
+          width: "calc(100% + 2px)",
+          maxWidth: "calc(100% + 2px)",
+          marginLeft: "-1px",
+          marginRight: "-1px",
+          marginBottom: "-1px",
+        }}
+        className={cn(
+          "rounded-b-xl rounded-t-lg border bg-white shadow-none",
+          "focus-within:border-border focus-within:ring-0",
+          "dark:bg-input/30",
+        )}
+      >
+        <PromptInputHeader>
+          <PromptInputAttachments />
+        </PromptInputHeader>
+        {variant === "floating" && (
+          <PromptInputToolbar inline>
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          </PromptInputToolbar>
+        )}
+        <PromptInputBody>
+          <PromptInputTextarea placeholder={placeholder} />
+        </PromptInputBody>
+        <PromptInputFooter>
+          <PromptInputToolbar>
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          </PromptInputToolbar>
+          <PromptInputActions>
+            <PromptInputMicButton />
+            <PromptInputSubmit
+              status={isProcessing ? "streaming" : "ready"}
+              onClick={(e) => {
+                if (isProcessing) {
+                  e.preventDefault();
+                  setIsProcessing(false);
+                }
+              }}
+            />
+          </PromptInputActions>
+        </PromptInputFooter>
+      </PromptInput>
+    </div>
+  );
+}
+
+export default function PromptInputQueuedDemo() {
+  return (
+    <div className="flex w-full flex-col gap-8 p-8">
+      <div className="relative flex min-h-[420px] w-full flex-col items-center justify-end p-4">
+        <QueuedPromptCard variant="default" placeholder="Message..." />
+      </div>
+
+      <div className="relative flex min-h-[420px] w-full flex-col items-center justify-end gap-4 rounded-lg bg-muted/30 p-8">
+        <QueuedPromptCard
+          variant="floating"
+          placeholder="Edit this page…"
+          shellShadowClass="shadow-lg"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/content/bloks/prompt-input.tsx
+++ b/src/app/content/bloks/prompt-input.tsx
@@ -14,7 +14,459 @@ import {
   PromptInputTextarea,
   PromptInputToolbar,
 } from "@/components/bloks/prompt-input";
-import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  SearchInput,
+  SearchInputClearButton,
+  SearchInputField,
+  SearchInputLeftElement,
+  SearchInputRightElement,
+} from "@/components/ui/search-input";
+import { Icon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import {
+  mdiAccountGroup,
+  mdiAccountOutline,
+  mdiAt,
+  mdiBugOutline,
+  mdiChartLine,
+  mdiCircleOutline,
+  mdiDatabaseOutline,
+  mdiDotsHexagon,
+  mdiFileDocumentOutline,
+  mdiFileOutline,
+  mdiFormatListBulleted,
+  mdiGraphOutline,
+  mdiHammerWrench,
+  mdiLightningBolt,
+  mdiMagnify,
+  mdiOfficeBuilding,
+  mdiPaperclip,
+  mdiPlus,
+  mdiRobotOutline,
+  mdiShieldCheck,
+  mdiSourceBranch,
+  mdiStarFourPoints,
+  mdiTextBoxSearch,
+  mdiWeb,
+} from "@mdi/js";
+import { useMemo, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// PromptInput “+” attach menu (demo data & layout — not part of core blok)
+// ---------------------------------------------------------------------------
+
+const promptInputAttachMenuItemClass =
+  "gap-3 py-2.5 pr-2 pl-2.5 [&>svg:first-child]:size-[18px] [&>svg:first-child]:text-muted-foreground";
+
+const promptInputAttachSubTriggerClass =
+  "gap-3 py-2.5 pl-2.5 pr-1 [&>svg:first-child]:size-[18px] [&>svg:first-child]:text-muted-foreground";
+
+type AttachMenuSubmenuChip = {
+  path: string;
+  className: string;
+};
+
+type AttachMenuSubmenuItem = {
+  id: string;
+  label: string;
+  leading?: AttachMenuSubmenuChip;
+  trailing?: readonly AttachMenuSubmenuChip[];
+};
+
+const ATTACH_MENU_DEMO_AGENTS: readonly AttachMenuSubmenuItem[] = [
+  {
+    id: "agent-1",
+    label: "Research assistant",
+    leading: { path: mdiRobotOutline, className: "bg-red-500" },
+  },
+  {
+    id: "agent-2",
+    label: "Code reviewer",
+    leading: { path: mdiAccountOutline, className: "bg-emerald-500" },
+  },
+  {
+    id: "agent-3",
+    label: "Support triage",
+    leading: { path: mdiStarFourPoints, className: "bg-violet-500" },
+  },
+  {
+    id: "agent-4",
+    label: "Documentation helper",
+    leading: { path: mdiTextBoxSearch, className: "bg-sky-500" },
+  },
+  {
+    id: "agent-5",
+    label: "Analytics copilot",
+    leading: { path: mdiChartLine, className: "bg-indigo-500" },
+  },
+  {
+    id: "agent-6",
+    label: "Security guard",
+    leading: { path: mdiShieldCheck, className: "bg-slate-600" },
+  },
+];
+
+const ATTACH_MENU_DEMO_FLOWS: readonly AttachMenuSubmenuItem[] = [
+  {
+    id: "flow-1",
+    label: "Handoff to human",
+    trailing: [
+      { path: mdiSourceBranch, className: "bg-emerald-500" },
+      { path: mdiFileDocumentOutline, className: "bg-violet-500" },
+    ],
+  },
+  {
+    id: "flow-2",
+    label: "Daily standup summary",
+    trailing: [
+      { path: mdiFormatListBulleted, className: "bg-blue-500" },
+      { path: mdiAccountGroup, className: "bg-red-500" },
+      { path: mdiPlus, className: "bg-fuchsia-500" },
+    ],
+  },
+  {
+    id: "flow-3",
+    label: "Release checklist",
+    trailing: [
+      { path: mdiFileOutline, className: "bg-sky-400" },
+      { path: mdiWeb, className: "bg-amber-500" },
+      { path: mdiAccountOutline, className: "bg-indigo-400" },
+      { path: mdiLightningBolt, className: "bg-rose-500" },
+    ],
+  },
+  {
+    id: "flow-4",
+    label: "Incident response",
+    trailing: [
+      { path: mdiBugOutline, className: "bg-orange-500" },
+      { path: mdiSourceBranch, className: "bg-teal-600" },
+    ],
+  },
+  {
+    id: "flow-5",
+    label: "Customer onboarding",
+    trailing: [
+      { path: mdiAccountGroup, className: "bg-blue-500" },
+      { path: mdiFileDocumentOutline, className: "bg-violet-500" },
+      { path: mdiPlus, className: "bg-pink-500" },
+    ],
+  },
+  {
+    id: "flow-6",
+    label: "Invoice automation",
+    trailing: [
+      { path: mdiFormatListBulleted, className: "bg-emerald-600" },
+      { path: mdiDatabaseOutline, className: "bg-slate-500" },
+    ],
+  },
+];
+
+const ATTACH_MENU_DEMO_TOOLS: readonly AttachMenuSubmenuItem[] = [
+  {
+    id: "tool-1",
+    label: "Web search",
+    trailing: [
+      { path: mdiWeb, className: "bg-blue-500" },
+      { path: mdiRobotOutline, className: "bg-violet-500" },
+    ],
+  },
+  {
+    id: "tool-2",
+    label: "Calculator",
+    trailing: [
+      { path: mdiFormatListBulleted, className: "bg-emerald-500" },
+      { path: mdiDatabaseOutline, className: "bg-slate-500" },
+      { path: mdiPlus, className: "bg-fuchsia-500" },
+    ],
+  },
+  {
+    id: "tool-3",
+    label: "SQL runner",
+    trailing: [
+      { path: mdiSourceBranch, className: "bg-red-500" },
+      { path: mdiFileDocumentOutline, className: "bg-amber-500" },
+    ],
+  },
+  {
+    id: "tool-4",
+    label: "API explorer",
+    trailing: [
+      { path: mdiWeb, className: "bg-cyan-600" },
+      { path: mdiLightningBolt, className: "bg-yellow-500" },
+      { path: mdiRobotOutline, className: "bg-purple-600" },
+    ],
+  },
+  {
+    id: "tool-5",
+    label: "Image studio",
+    trailing: [
+      { path: mdiFileOutline, className: "bg-rose-500" },
+      { path: mdiStarFourPoints, className: "bg-fuchsia-500" },
+    ],
+  },
+  {
+    id: "tool-6",
+    label: "Log tailer",
+    trailing: [
+      { path: mdiFormatListBulleted, className: "bg-stone-500" },
+      { path: mdiAccountOutline, className: "bg-blue-600" },
+      { path: mdiPlus, className: "bg-green-600" },
+    ],
+  },
+];
+
+const ATTACH_MENU_DEMO_CONTEXT: readonly AttachMenuSubmenuItem[] = [
+  {
+    id: "ctx-1",
+    label: "Martech company",
+    leading: {
+      path: mdiOfficeBuilding,
+      className: "bg-gradient-to-br from-amber-400 via-red-500 to-blue-600",
+    },
+  },
+  {
+    id: "ctx-2",
+    label: "Sitecore",
+    leading: { path: mdiCircleOutline, className: "bg-rose-600" },
+  },
+  {
+    id: "ctx-3",
+    label: "SitecoreAI",
+    leading: { path: mdiDotsHexagon, className: "bg-fuchsia-600" },
+  },
+];
+
+function AttachMenuChipTile({ path, className }: AttachMenuSubmenuChip) {
+  return (
+    <span
+      className={cn(
+        "flex size-7 shrink-0 items-center justify-center rounded-md text-white shadow-sm",
+        className,
+      )}
+      aria-hidden
+    >
+      <Icon path={path} className="size-4 text-white" />
+    </span>
+  );
+}
+
+function AttachMenuTrailingIcons({
+  icons,
+}: {
+  icons: readonly AttachMenuSubmenuChip[];
+}) {
+  return (
+    <span className="flex shrink-0 items-center justify-end gap-1" aria-hidden>
+      {icons.map((tic, i) => (
+        <AttachMenuChipTile key={i} {...tic} />
+      ))}
+    </span>
+  );
+}
+
+function AttachMenuCategorySub({
+  icon,
+  label,
+  searchPlaceholder,
+  items,
+  showItemTrailingIcons = false,
+}: {
+  icon: string;
+  label: string;
+  searchPlaceholder: string;
+  items: readonly AttachMenuSubmenuItem[];
+  showItemTrailingIcons?: boolean;
+}) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [...items];
+    return items.filter((entry) => entry.label.toLowerCase().includes(q));
+  }, [items, query]);
+
+  return (
+    <DropdownMenuSub
+      onOpenChange={(open) => {
+        if (!open) setQuery("");
+      }}
+    >
+      <DropdownMenuSubTrigger className={promptInputAttachSubTriggerClass}>
+        <Icon path={icon} className="shrink-0" />
+        <span className="min-w-0 flex-1 text-left font-normal">{label}</span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuPortal>
+        <DropdownMenuSubContent
+          className={cn(
+            "min-w-0 overflow-x-hidden rounded-lg p-0",
+            showItemTrailingIcons
+              ? "w-[min(100vw-2rem,24rem)] max-w-[min(100vw-2rem,26rem)]"
+              : "min-w-68 max-w-[min(100vw-2rem,26rem)]",
+          )}
+        >
+          <div
+            className="p-2"
+            onPointerDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <SearchInput className="h-8">
+              <SearchInputLeftElement className="pl-2 [&>svg:not([class*='size-'])]:size-4">
+                <Icon path={mdiMagnify} />
+              </SearchInputLeftElement>
+              <SearchInputField
+                placeholder={searchPlaceholder}
+                aria-label={searchPlaceholder}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="h-8 text-sm"
+              />
+              {query ? (
+                <SearchInputRightElement className="pr-0.5">
+                  <SearchInputClearButton onClear={() => setQuery("")} />
+                </SearchInputRightElement>
+              ) : null}
+            </SearchInput>
+          </div>
+          <div className="max-h-[min(20rem,60vh)] w-full min-w-0 overflow-x-hidden overflow-y-auto py-1">
+            {filtered.length === 0 ? (
+              <div className="text-muted-foreground px-2 py-3 text-center text-xs">
+                No results
+              </div>
+            ) : (
+              filtered.map((entry) => {
+                const hasTrailing =
+                  showItemTrailingIcons &&
+                  entry.trailing &&
+                  entry.trailing.length > 0;
+                return (
+                  <DropdownMenuItem
+                    key={entry.id}
+                    className={cn(
+                      "min-w-0 items-center py-2",
+                      hasTrailing
+                        ? "flex w-full min-w-0 justify-between gap-0! px-3"
+                        : "flex gap-2.5 px-2",
+                    )}
+                  >
+                    {!showItemTrailingIcons && entry.leading ? (
+                      <AttachMenuChipTile {...entry.leading} />
+                    ) : null}
+                    <span
+                      className={cn(
+                        "min-w-0 truncate text-left",
+                        hasTrailing ? "max-w-[62%] shrink" : "flex-1",
+                      )}
+                    >
+                      {entry.label}
+                    </span>
+                    {hasTrailing && entry.trailing ? (
+                      <AttachMenuTrailingIcons icons={entry.trailing} />
+                    ) : null}
+                  </DropdownMenuItem>
+                );
+              })
+            )}
+          </div>
+        </DropdownMenuSubContent>
+      </DropdownMenuPortal>
+    </DropdownMenuSub>
+  );
+}
+
+export function PromptInputAttachMenuPanel({
+  onAttachFile,
+}: {
+  onAttachFile: () => void;
+}) {
+  return (
+    <>
+      <DropdownMenuItem
+        className={promptInputAttachMenuItemClass}
+        onSelect={() => {
+          onAttachFile();
+        }}
+      >
+        <Icon path={mdiPaperclip} className="shrink-0" />
+        <span className="min-w-0 flex-1 font-normal">Attach file</span>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <AttachMenuCategorySub
+        icon={mdiStarFourPoints}
+        label="Agents"
+        searchPlaceholder="Search agents"
+        items={ATTACH_MENU_DEMO_AGENTS}
+      />
+      <AttachMenuCategorySub
+        icon={mdiGraphOutline}
+        label="Flows"
+        searchPlaceholder="Search flows"
+        items={ATTACH_MENU_DEMO_FLOWS}
+        showItemTrailingIcons
+      />
+      <AttachMenuCategorySub
+        icon={mdiHammerWrench}
+        label="Tools"
+        searchPlaceholder="Search tools"
+        items={ATTACH_MENU_DEMO_TOOLS}
+        showItemTrailingIcons
+      />
+      <AttachMenuCategorySub
+        icon={mdiAt}
+        label="Context"
+        searchPlaceholder="Search context"
+        items={ATTACH_MENU_DEMO_CONTEXT}
+      />
+    </>
+  );
+}
+
+/** Shared attach dropdown for prompt-input demos (default + floating). */
+export function promptInputDemoAttachMenu({
+  openFileDialog,
+}: {
+  openFileDialog: () => void;
+}) {
+  return <PromptInputAttachMenuPanel onAttachFile={openFileDialog} />;
+}
+
+/** Isolated attach dropdown preview (e.g. docsite). */
+export function PromptInputAttachMenuContentDemo() {
+  return (
+    <div className="flex justify-center p-4">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" colorScheme="neutral">
+            Open attach menu
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          side="bottom"
+          align="start"
+          sideOffset={6}
+          className="min-w-0 w-[min(100vw-2rem,13rem)] rounded-lg"
+        >
+          <PromptInputAttachMenuPanel onAttachFile={() => {}} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Default variant demo
+// ---------------------------------------------------------------------------
 
 export default function PromptInputDemo() {
   const [lastMessage, setLastMessage] = useState<string>("");
@@ -34,7 +486,7 @@ export default function PromptInputDemo() {
         </PromptInputBody>
         <PromptInputFooter>
           <PromptInputToolbar>
-            <PromptInputAttachButton />
+            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
           </PromptInputToolbar>
           <PromptInputActions>
             <PromptInputMicButton />

--- a/src/app/content/bloks/prompt-input.tsx
+++ b/src/app/content/bloks/prompt-input.tsx
@@ -1,0 +1,52 @@
+"use client"; // Please remove this if you are not using nextjs
+
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  type PromptInputMessage,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/components/bloks/prompt-input";
+import { useState } from "react";
+
+export default function PromptInputDemo() {
+  const [lastMessage, setLastMessage] = useState<string>("");
+
+  const handleSubmit = (message: PromptInputMessage) => {
+    setLastMessage(message.text);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-6 p-8 min-h-[300px] w-full max-w-2xl mx-auto">
+      <PromptInput variant="default" onSubmit={handleSubmit}>
+        <PromptInputHeader>
+          <PromptInputAttachments />
+        </PromptInputHeader>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+        <PromptInputFooter>
+          <PromptInputToolbar>
+            <PromptInputAttachButton />
+          </PromptInputToolbar>
+          <PromptInputActions>
+            <PromptInputMicButton />
+            <PromptInputSubmit />
+          </PromptInputActions>
+        </PromptInputFooter>
+      </PromptInput>
+      {lastMessage && (
+        <p className="text-sm text-muted-foreground">
+          Last sent: &ldquo;{lastMessage}&rdquo;
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/content/bloks/prompt-input.tsx
+++ b/src/app/content/bloks/prompt-input.tsx
@@ -10,9 +10,12 @@ import {
   PromptInputHeader,
   type PromptInputMessage,
   PromptInputMicButton,
+  type PromptInputSelection,
+  PromptInputSelections,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputToolbar,
+  usePromptInputContext,
 } from "@/components/bloks/prompt-input";
 import { Button } from "@/components/ui/button";
 import {
@@ -282,12 +285,14 @@ function AttachMenuCategorySub({
   searchPlaceholder,
   items,
   showItemTrailingIcons = false,
+  onSelectItem,
 }: {
   icon: string;
   label: string;
   searchPlaceholder: string;
   items: readonly AttachMenuSubmenuItem[];
   showItemTrailingIcons?: boolean;
+  onSelectItem?: (selection: PromptInputSelection) => void;
 }) {
   const [query, setQuery] = useState("");
 
@@ -350,9 +355,22 @@ function AttachMenuCategorySub({
                   showItemTrailingIcons &&
                   entry.trailing &&
                   entry.trailing.length > 0;
+                const chipIcon =
+                  entry.leading ??
+                  (entry.trailing && entry.trailing.length > 0
+                    ? entry.trailing[0]
+                    : { path: icon, className: "bg-muted-foreground/40" });
                 return (
                   <DropdownMenuItem
                     key={entry.id}
+                    onSelect={() => {
+                      onSelectItem?.({
+                        id: `${label.toLowerCase()}-${entry.id}`,
+                        label: entry.label,
+                        iconPath: chipIcon.path,
+                        iconClassName: chipIcon.className,
+                      });
+                    }}
                     className={cn(
                       "min-w-0 items-center py-2",
                       hasTrailing
@@ -387,8 +405,10 @@ function AttachMenuCategorySub({
 
 export function PromptInputAttachMenuPanel({
   onAttachFile,
+  onSelectItem,
 }: {
   onAttachFile: () => void;
+  onSelectItem?: (selection: PromptInputSelection) => void;
 }) {
   return (
     <>
@@ -407,6 +427,7 @@ export function PromptInputAttachMenuPanel({
         label="Agents"
         searchPlaceholder="Search agents"
         items={ATTACH_MENU_DEMO_AGENTS}
+        onSelectItem={onSelectItem}
       />
       <AttachMenuCategorySub
         icon={mdiGraphOutline}
@@ -414,6 +435,7 @@ export function PromptInputAttachMenuPanel({
         searchPlaceholder="Search flows"
         items={ATTACH_MENU_DEMO_FLOWS}
         showItemTrailingIcons
+        onSelectItem={onSelectItem}
       />
       <AttachMenuCategorySub
         icon={mdiHammerWrench}
@@ -421,14 +443,34 @@ export function PromptInputAttachMenuPanel({
         searchPlaceholder="Search tools"
         items={ATTACH_MENU_DEMO_TOOLS}
         showItemTrailingIcons
+        onSelectItem={onSelectItem}
       />
       <AttachMenuCategorySub
         icon={mdiAt}
         label="Context"
         searchPlaceholder="Search context"
         items={ATTACH_MENU_DEMO_CONTEXT}
+        onSelectItem={onSelectItem}
       />
     </>
+  );
+}
+
+/**
+ * Connects `PromptInputAttachMenuPanel` to the surrounding `PromptInput`
+ * context so picked items become inline selection chips.
+ */
+function PromptInputAttachMenuPanelConnected({
+  onAttachFile,
+}: {
+  onAttachFile: () => void;
+}) {
+  const { addSelection } = usePromptInputContext();
+  return (
+    <PromptInputAttachMenuPanel
+      onAttachFile={onAttachFile}
+      onSelectItem={addSelection}
+    />
   );
 }
 
@@ -438,7 +480,7 @@ export function promptInputDemoAttachMenu({
 }: {
   openFileDialog: () => void;
 }) {
-  return <PromptInputAttachMenuPanel onAttachFile={openFileDialog} />;
+  return <PromptInputAttachMenuPanelConnected onAttachFile={openFileDialog} />;
 }
 
 /** Isolated attach dropdown preview (e.g. docsite). */
@@ -487,6 +529,7 @@ export default function PromptInputDemo() {
         <PromptInputFooter>
           <PromptInputToolbar>
             <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
             <PromptInputMicButton />

--- a/src/app/demo/[name]/bloks/prompt-input.tsx
+++ b/src/app/demo/[name]/bloks/prompt-input.tsx
@@ -5,104 +5,23 @@ export const promptInput = {
   },
   usage: {
     usage: [
-      `import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
-import {
+      `import {
   PromptInput,
-  PromptInputActions,
-  PromptInputAttachButton,
-  PromptInputAttachments,
   PromptInputBody,
   PromptInputFooter,
-  PromptInputHeader,
-  PromptInputMicButton,
+  PromptInputActions,
   PromptInputSubmit,
   PromptInputTextarea,
-  PromptInputToolbar,
-} from "@/components/bloks/prompt-input";
-
-// Default variant — for chatbots
-<PromptInput variant="default" onSubmit={(msg) => console.log(msg)}>
-  <PromptInputHeader>
-    <PromptInputAttachments />
-  </PromptInputHeader>
+} from "@/components/bloks/prompt-input"`,
+      `<PromptInput onSubmit={(msg) => console.log(msg.text)}>
   <PromptInputBody>
     <PromptInputTextarea />
   </PromptInputBody>
   <PromptInputFooter>
-    <PromptInputToolbar>
-      <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
-    </PromptInputToolbar>
     <PromptInputActions>
-      <PromptInputMicButton />
       <PromptInputSubmit />
     </PromptInputActions>
   </PromptInputFooter>
-</PromptInput>`,
-      `import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
-import {
-  PromptInput,
-  PromptInputActions,
-  PromptInputAttachButton,
-  PromptInputAttachments,
-  PromptInputBody,
-  PromptInputFooter,
-  PromptInputHeader,
-  PromptInputMicButton,
-  PromptInputSubmit,
-  PromptInputTextarea,
-  PromptInputToolbar,
-} from "@/components/bloks/prompt-input";
-
-// Floating variant — for in-page editing and canvas
-// Uses inline toolbar (single-line row) + regular toolbar (multiline column)
-<PromptInput variant="floating" onSubmit={(msg) => console.log(msg)}>
-  <PromptInputHeader>
-    <PromptInputAttachments />
-  </PromptInputHeader>
-  <PromptInputToolbar inline>
-    <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
-  </PromptInputToolbar>
-  <PromptInputBody>
-    <PromptInputTextarea placeholder="Edit this page…" />
-  </PromptInputBody>
-  <PromptInputFooter>
-    <PromptInputToolbar>
-      <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
-    </PromptInputToolbar>
-    <PromptInputActions>
-      <PromptInputMicButton />
-      <PromptInputSubmit />
-    </PromptInputActions>
-  </PromptInputFooter>
-</PromptInput>`,
-      `import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
-import {
-  PromptInput,
-  PromptInputActions,
-  PromptInputAttachButton,
-  PromptInputAttachments,
-  PromptInputBody,
-  PromptInputFooter,
-  PromptInputHeader,
-  PromptInputMicButton,
-  PromptInputSubmit,
-  PromptInputTextarea,
-  PromptInputToolbar,
-} from "@/components/bloks/prompt-input";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-
-// Compose a queue panel above the field; drive PromptInputSubmit with status="streaming" for stop.
-<Collapsible defaultOpen>
-  <CollapsibleTrigger>{/* chevron + "N prompts queued" */}</CollapsibleTrigger>
-  <CollapsibleContent>{/* pending rows */}</CollapsibleContent>
-</Collapsible>
-<PromptInput variant="default" onSubmit={handleSubmit}>
-  {/* header / body / footer */}
-  <PromptInputSubmit status={busy ? "streaming" : "ready"} />
 </PromptInput>`,
     ],
   },
@@ -112,6 +31,9 @@ import {
     },
     Queued: {
       component: "prompt-input-queued",
+    },
+    Questions: {
+      component: "prompt-input-questions",
     },
   },
 };

--- a/src/app/demo/[name]/bloks/prompt-input.tsx
+++ b/src/app/demo/[name]/bloks/prompt-input.tsx
@@ -5,7 +5,8 @@ export const promptInput = {
   },
   usage: {
     usage: [
-      `import {
+      `import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
+import {
   PromptInput,
   PromptInputActions,
   PromptInputAttachButton,
@@ -29,7 +30,7 @@ export const promptInput = {
   </PromptInputBody>
   <PromptInputFooter>
     <PromptInputToolbar>
-      <PromptInputAttachButton />
+      <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
     </PromptInputToolbar>
     <PromptInputActions>
       <PromptInputMicButton />
@@ -37,19 +38,36 @@ export const promptInput = {
     </PromptInputActions>
   </PromptInputFooter>
 </PromptInput>`,
-      `// Floating variant — for in-page editing and canvas
+      `import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/components/bloks/prompt-input";
+
+// Floating variant — for in-page editing and canvas
 // Uses inline toolbar (single-line row) + regular toolbar (multiline column)
 <PromptInput variant="floating" onSubmit={(msg) => console.log(msg)}>
-  <PromptInputAttachments />
+  <PromptInputHeader>
+    <PromptInputAttachments />
+  </PromptInputHeader>
   <PromptInputToolbar inline>
-    <PromptInputAttachButton />
+    <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
   </PromptInputToolbar>
   <PromptInputBody>
-    <PromptInputTextarea />
+    <PromptInputTextarea placeholder="Edit this page…" />
   </PromptInputBody>
   <PromptInputFooter>
     <PromptInputToolbar>
-      <PromptInputAttachButton />
+      <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
     </PromptInputToolbar>
     <PromptInputActions>
       <PromptInputMicButton />

--- a/src/app/demo/[name]/bloks/prompt-input.tsx
+++ b/src/app/demo/[name]/bloks/prompt-input.tsx
@@ -1,0 +1,67 @@
+export const promptInput = {
+  name: "prompt-input",
+  preview: {
+    defaultComponent: "prompt-input",
+  },
+  usage: {
+    usage: [
+      `import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/components/bloks/prompt-input";
+
+// Default variant — for chatbots
+<PromptInput variant="default" onSubmit={(msg) => console.log(msg)}>
+  <PromptInputHeader>
+    <PromptInputAttachments />
+  </PromptInputHeader>
+  <PromptInputBody>
+    <PromptInputTextarea />
+  </PromptInputBody>
+  <PromptInputFooter>
+    <PromptInputToolbar>
+      <PromptInputAttachButton />
+    </PromptInputToolbar>
+    <PromptInputActions>
+      <PromptInputMicButton />
+      <PromptInputSubmit />
+    </PromptInputActions>
+  </PromptInputFooter>
+</PromptInput>`,
+      `// Floating variant — for in-page editing and canvas
+// Uses inline toolbar (single-line row) + regular toolbar (multiline column)
+<PromptInput variant="floating" onSubmit={(msg) => console.log(msg)}>
+  <PromptInputAttachments />
+  <PromptInputToolbar inline>
+    <PromptInputAttachButton />
+  </PromptInputToolbar>
+  <PromptInputBody>
+    <PromptInputTextarea />
+  </PromptInputBody>
+  <PromptInputFooter>
+    <PromptInputToolbar>
+      <PromptInputAttachButton />
+    </PromptInputToolbar>
+    <PromptInputActions>
+      <PromptInputMicButton />
+      <PromptInputSubmit />
+    </PromptInputActions>
+  </PromptInputFooter>
+</PromptInput>`,
+    ],
+  },
+  components: {
+    Floating: {
+      component: "prompt-input-floating",
+    },
+  },
+};

--- a/src/app/demo/[name]/bloks/prompt-input.tsx
+++ b/src/app/demo/[name]/bloks/prompt-input.tsx
@@ -75,11 +75,43 @@ import {
     </PromptInputActions>
   </PromptInputFooter>
 </PromptInput>`,
+      `import { promptInputDemoAttachMenu } from "@/app/content/bloks/prompt-input";
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttachButton,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputHeader,
+  PromptInputMicButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputToolbar,
+} from "@/components/bloks/prompt-input";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+
+// Compose a queue panel above the field; drive PromptInputSubmit with status="streaming" for stop.
+<Collapsible defaultOpen>
+  <CollapsibleTrigger>{/* chevron + "N prompts queued" */}</CollapsibleTrigger>
+  <CollapsibleContent>{/* pending rows */}</CollapsibleContent>
+</Collapsible>
+<PromptInput variant="default" onSubmit={handleSubmit}>
+  {/* header / body / footer */}
+  <PromptInputSubmit status={busy ? "streaming" : "ready"} />
+</PromptInput>`,
     ],
   },
   components: {
     Floating: {
       component: "prompt-input-floating",
+    },
+    Queued: {
+      component: "prompt-input-queued",
     },
   },
 };

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -70,6 +70,7 @@ import { allSite } from "@/app/demo/[name]/bloks/all-site";
 import { collaboration } from "@/app/demo/[name]/bloks/collaboration";
 import { dashboardWidget } from "@/app/demo/[name]/bloks/dashboard-widget";
 import { pinnedSite } from "@/app/demo/[name]/bloks/pinned-site";
+import { promptInput } from "@/app/demo/[name]/bloks/prompt-input";
 import { sidebarRhs } from "@/app/demo/[name]/bloks/sidebar-rhs";
 import { siteCard } from "@/app/demo/[name]/bloks/site-card";
 
@@ -170,5 +171,6 @@ export const demos: { [name: string]: Demo } = {
   "site-card": siteCard,
   "pinned-site": pinnedSite,
   collaboration,
+  "prompt-input": promptInput,
   "sidebar-rhs": sidebarRhs,
 };

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -30,6 +30,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useId,
   useLayoutEffect,
   useRef,
@@ -75,6 +76,14 @@ interface PromptInputContextValue {
   multiple?: boolean;
   maxFiles?: number;
   maxFileSize?: number;
+  /** Inline voice capture: waveform in the text area; stop on the submit control. */
+  isRecording: boolean;
+  recordingDurationSec: number;
+  recordingAnalyser: AnalyserNode | null;
+  startVoiceRecording: () => Promise<void>;
+  cancelVoiceRecording: () => void;
+  confirmVoiceRecording: () => void;
+  recordingError: string | null;
 }
 
 const PromptInputContext = createContext<PromptInputContextValue | null>(null);
@@ -118,6 +127,70 @@ export const PROMPT_INPUT_FORM_MIN_WIDTH_PX =
   3 * 6 +
   48;
 
+/** Vertical bars in the recording waveform. */
+const VOICE_WAVE_BAR_COUNT = 52;
+
+function pickAudioMimeType(): string {
+  const candidates = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"];
+  for (const t of candidates) {
+    if (
+      typeof MediaRecorder !== "undefined" &&
+      MediaRecorder.isTypeSupported(t)
+    ) {
+      return t;
+    }
+  }
+  return "";
+}
+
+/** Centered vertical frequency bars scaling from the middle. */
+function PromptInputVoiceWaveform({
+  analyser,
+}: { analyser: AnalyserNode | null }) {
+  const barRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    if (!analyser) return;
+    const data = new Uint8Array(analyser.frequencyBinCount);
+    let raf = 0;
+    const tick = () => {
+      analyser.getByteFrequencyData(data);
+      const n = VOICE_WAVE_BAR_COUNT;
+      for (let i = 0; i < n; i++) {
+        const t = i / (n - 1 || 1);
+        const idx = Math.floor(t * (data.length - 1));
+        const raw = data[idx] ?? 0;
+        const v = raw / 255;
+        const eased = v ** 0.65;
+        const scale = 0.12 + eased * 0.88;
+        const el = barRefs.current[i];
+        if (el) el.style.transform = `scaleY(${scale})`;
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [analyser]);
+
+  return (
+    <div
+      className="flex min-w-0 flex-1 items-center justify-center gap-[3px] px-1"
+      aria-hidden
+    >
+      {Array.from({ length: VOICE_WAVE_BAR_COUNT }, (_, i) => (
+        <div
+          key={i}
+          ref={(el) => {
+            barRefs.current[i] = el;
+          }}
+          className="h-7 w-0.5 shrink-0 origin-center rounded-full bg-primary dark:bg-primary/45"
+          style={{ transform: "scaleY(0.12)" }}
+        />
+      ))}
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // PromptInput (root)
 // ---------------------------------------------------------------------------
@@ -147,12 +220,28 @@ function PromptInput({
   className,
   children,
   style,
+  onKeyDown,
   ...props
 }: PromptInputProps) {
   const [files, setFiles] = useState<PromptInputFile[]>([]);
   const [isMultiline, setIsMultiline] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordingDurationSec, setRecordingDurationSec] = useState(0);
+  const [recordingAnalyser, setRecordingAnalyser] =
+    useState<AnalyserNode | null>(null);
+  const [recordingError, setRecordingError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const voiceStreamRef = useRef<MediaStream | null>(null);
+  const voiceAudioContextRef = useRef<AudioContext | null>(null);
+  const voiceMediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const voiceChunksRef = useRef<Blob[]>([]);
+  const voiceDiscardRef = useRef(false);
+  const voiceMimeRef = useRef("");
+  const voiceDurationTimerRef = useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  const voiceStartingRef = useRef(false);
 
   const addFiles = useCallback(
     (incoming: FileList | File[]) => {
@@ -228,9 +317,159 @@ function PromptInput({
     fileInputRef.current?.click();
   }, []);
 
+  const cleanupVoiceResources = useCallback(() => {
+    voiceStreamRef.current?.getTracks().forEach((t) => t.stop());
+    voiceStreamRef.current = null;
+    const ctx = voiceAudioContextRef.current;
+    voiceAudioContextRef.current = null;
+    if (ctx && ctx.state !== "closed") {
+      void ctx.close().catch(() => {});
+    }
+    voiceMediaRecorderRef.current = null;
+    setRecordingAnalyser(null);
+  }, []);
+
+  const startVoiceRecording = useCallback(async () => {
+    if (
+      voiceStartingRef.current ||
+      voiceMediaRecorderRef.current?.state === "recording"
+    ) {
+      return;
+    }
+    voiceStartingRef.current = true;
+    setRecordingError(null);
+    voiceDiscardRef.current = false;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      voiceStreamRef.current = stream;
+
+      const audioCtx = new AudioContext();
+      voiceAudioContextRef.current = audioCtx;
+      if (audioCtx.state === "suspended") {
+        await audioCtx.resume();
+      }
+      const source = audioCtx.createMediaStreamSource(stream);
+      const analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 512;
+      analyser.smoothingTimeConstant = 0.72;
+      source.connect(analyser);
+      setRecordingAnalyser(analyser);
+
+      const mime = pickAudioMimeType();
+      voiceMimeRef.current = mime;
+      const recorder = mime
+        ? new MediaRecorder(stream, { mimeType: mime })
+        : new MediaRecorder(stream);
+      voiceMediaRecorderRef.current = recorder;
+      voiceChunksRef.current = [];
+
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) voiceChunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = () => {
+        if (voiceDurationTimerRef.current) {
+          clearInterval(voiceDurationTimerRef.current);
+          voiceDurationTimerRef.current = null;
+        }
+
+        const discard = voiceDiscardRef.current;
+        const chunks = voiceChunksRef.current;
+        voiceChunksRef.current = [];
+        const usedMime = voiceMimeRef.current;
+
+        cleanupVoiceResources();
+        setIsRecording(false);
+        setRecordingDurationSec(0);
+        voiceMimeRef.current = "";
+
+        if (discard || chunks.length === 0) {
+          return;
+        }
+
+        const blobType = usedMime || chunks[0]?.type || "audio/webm";
+        const blob = new Blob(chunks, { type: blobType });
+        const ext = blobType.includes("mp4") ? "m4a" : "webm";
+        const file = new File([blob], `Voice message.${ext}`, {
+          type: blob.type || blobType,
+        });
+        addFiles([file]);
+      };
+
+      recorder.start(120);
+      setIsRecording(true);
+      setRecordingDurationSec(0);
+      voiceDurationTimerRef.current = setInterval(() => {
+        setRecordingDurationSec((s) => s + 1);
+      }, 1000);
+    } catch (e) {
+      const msg =
+        e instanceof Error ? e.message : "Microphone access was denied.";
+      setRecordingError(msg);
+      cleanupVoiceResources();
+      setIsRecording(false);
+      setRecordingDurationSec(0);
+    } finally {
+      voiceStartingRef.current = false;
+    }
+  }, [addFiles, cleanupVoiceResources]);
+
+  const cancelVoiceRecording = useCallback(() => {
+    voiceDiscardRef.current = true;
+    if (voiceDurationTimerRef.current) {
+      clearInterval(voiceDurationTimerRef.current);
+      voiceDurationTimerRef.current = null;
+    }
+    const rec = voiceMediaRecorderRef.current;
+    if (rec && rec.state !== "inactive") {
+      rec.stop();
+    } else {
+      cleanupVoiceResources();
+      voiceChunksRef.current = [];
+      setIsRecording(false);
+      setRecordingDurationSec(0);
+    }
+  }, [cleanupVoiceResources]);
+
+  const confirmVoiceRecording = useCallback(() => {
+    voiceDiscardRef.current = false;
+    if (voiceDurationTimerRef.current) {
+      clearInterval(voiceDurationTimerRef.current);
+      voiceDurationTimerRef.current = null;
+    }
+    const rec = voiceMediaRecorderRef.current;
+    if (rec && rec.state === "recording") {
+      rec.stop();
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      voiceDiscardRef.current = true;
+      if (voiceDurationTimerRef.current) {
+        clearInterval(voiceDurationTimerRef.current);
+        voiceDurationTimerRef.current = null;
+      }
+      const rec = voiceMediaRecorderRef.current;
+      if (rec && rec.state !== "inactive") {
+        try {
+          rec.stop();
+        } catch {
+          /* ignore */
+        }
+      }
+      voiceStreamRef.current?.getTracks().forEach((t) => t.stop());
+      const ctx = voiceAudioContextRef.current;
+      if (ctx && ctx.state !== "closed") {
+        void ctx.close().catch(() => {});
+      }
+    };
+  }, []);
+
   const handleSubmit = useCallback(
     (e: FormEvent) => {
       e.preventDefault();
+      if (isRecording) return;
       const text = textareaRef.current?.value?.trim() ?? "";
       if (!text && files.length === 0) return;
 
@@ -243,7 +482,7 @@ function PromptInput({
       setIsMultiline(false);
       clearFiles();
     },
-    [files, onSubmit, clearFiles],
+    [files, onSubmit, clearFiles, isRecording],
   );
 
   const handleFileInput = useCallback(
@@ -281,6 +520,13 @@ function PromptInput({
         multiple,
         maxFiles,
         maxFileSize,
+        isRecording,
+        recordingDurationSec,
+        recordingAnalyser,
+        startVoiceRecording,
+        cancelVoiceRecording,
+        confirmVoiceRecording,
+        recordingError,
       }}
     >
       <form
@@ -288,6 +534,15 @@ function PromptInput({
         data-variant={variant}
         data-multiline={isMultiline || undefined}
         onSubmit={handleSubmit}
+        data-recording={isRecording || undefined}
+        onKeyDown={(e) => {
+          onKeyDown?.(e);
+          if (e.defaultPrevented) return;
+          if (isRecording && e.key === "Escape") {
+            e.preventDefault();
+            cancelVoiceRecording();
+          }
+        }}
         className={cn(
           "group/prompt-input relative bg-white dark:bg-input/30 border transition-shadow",
           "focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/50",
@@ -397,8 +652,15 @@ function PromptInputTextarea({
   onKeyDown,
   ...props
 }: PromptInputTextareaProps) {
-  const { textareaRef, variant, setIsMultiline, isMultiline } =
-    usePromptInputContext();
+  const {
+    textareaRef,
+    variant,
+    setIsMultiline,
+    isMultiline,
+    isRecording,
+    recordingAnalyser,
+    recordingError,
+  } = usePromptInputContext();
   const id = useId();
   const inlineWidthRef = useRef(0);
 
@@ -456,27 +718,54 @@ function PromptInputTextarea({
     [onKeyDown],
   );
 
+  if (isRecording) {
+    return (
+      <div
+        data-slot="prompt-input-voice-meter"
+        className={cn(
+          "flex w-full min-w-0 items-center",
+          variant === "default" && "py-3",
+          variant === "floating" && "py-0",
+        )}
+        style={{
+          minHeight: `${resolvedMinHeight}px`,
+          maxHeight: `${resolvedMaxHeight}px`,
+        }}
+        aria-label="Recording audio"
+      >
+        <PromptInputVoiceWaveform analyser={recordingAnalyser} />
+      </div>
+    );
+  }
+
   return (
-    <Textarea
-      ref={textareaRef}
-      id={id}
-      data-slot="prompt-input-textarea"
-      rows={1}
-      placeholder={placeholder}
-      className={cn(
-        "w-full resize-none border-0 bg-transparent shadow-none ring-0 focus:ring-0 focus-visible:ring-0 focus-visible:border-0 rounded-none min-h-0 overflow-y-auto px-0",
-        variant === "default" && "py-3",
-        variant === "floating" && "py-0",
-        className,
-      )}
-      style={{
-        minHeight: `${resolvedMinHeight}px`,
-        maxHeight: `${resolvedMaxHeight}px`,
-      }}
-      onInput={handleInput}
-      onKeyDown={handleKeyDown}
-      {...props}
-    />
+    <>
+      {recordingError ? (
+        <p className="pb-1.5 text-xs text-destructive" role="alert">
+          {recordingError}
+        </p>
+      ) : null}
+      <Textarea
+        ref={textareaRef}
+        id={id}
+        data-slot="prompt-input-textarea"
+        rows={1}
+        placeholder={placeholder}
+        className={cn(
+          "w-full resize-none border-0 bg-transparent shadow-none ring-0 focus:ring-0 focus-visible:ring-0 focus-visible:border-0 rounded-none min-h-0 overflow-y-auto px-0",
+          variant === "default" && "py-3",
+          variant === "floating" && "py-0",
+          className,
+        )}
+        style={{
+          minHeight: `${resolvedMinHeight}px`,
+          maxHeight: `${resolvedMaxHeight}px`,
+        }}
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        {...props}
+      />
+    </>
   );
 }
 
@@ -617,9 +906,10 @@ function PromptInputButton({
 function PromptInputAttachButton({
   className,
   tooltip = "Add attachment",
+  disabled,
   ...props
 }: Omit<PromptInputButtonProps, "onClick">) {
-  const { openFileDialog } = usePromptInputContext();
+  const { openFileDialog, isRecording } = usePromptInputContext();
 
   return (
     <PromptInputButton
@@ -627,6 +917,7 @@ function PromptInputAttachButton({
       onClick={openFileDialog}
       className={cn("shrink-0", className)}
       {...props}
+      disabled={disabled || isRecording}
     >
       <Icon path={mdiPlus} className="size-5" />
     </PromptInputButton>
@@ -646,9 +937,33 @@ function PromptInputSubmit({
   status = "ready",
   className,
   disabled,
+  onClick,
   ...props
 }: PromptInputSubmitProps) {
+  const { isRecording, confirmVoiceRecording } = usePromptInputContext();
+
   const isStreaming = status === "submitted" || status === "streaming";
+
+  if (isRecording) {
+    return (
+      <Button
+        type="button"
+        variant="default"
+        size="icon-sm"
+        data-slot="prompt-input-submit"
+        disabled={disabled}
+        className={cn("shrink-0", className)}
+        aria-label="Stop recording"
+        {...props}
+        onClick={(e) => {
+          onClick?.(e);
+          if (!e.defaultPrevented) confirmVoiceRecording();
+        }}
+      >
+        <Icon path={mdiSquare} className="h-4! w-4! shrink-0" />
+      </Button>
+    );
+  }
 
   return (
     <Button
@@ -659,9 +974,10 @@ function PromptInputSubmit({
       disabled={disabled}
       className={cn("shrink-0", className)}
       {...props}
+      onClick={onClick}
     >
       {isStreaming ? (
-        <Icon path={mdiSquare} className="size-3" />
+        <Icon path={mdiSquare} className="h-4! w-4! shrink-0" />
       ) : (
         <Icon path={mdiArrowUp} className="size-5" />
       )}
@@ -934,10 +1250,23 @@ function PromptInputAttachments({
 function PromptInputMicButton({
   className,
   tooltip = "Voice input",
+  onClick,
+  disabled,
   ...props
 }: PromptInputButtonProps) {
+  const { startVoiceRecording, isRecording } = usePromptInputContext();
+
   return (
-    <PromptInputButton tooltip={tooltip} className={className} {...props}>
+    <PromptInputButton
+      tooltip={tooltip}
+      className={className}
+      onClick={(e) => {
+        onClick?.(e);
+        void startVoiceRecording();
+      }}
+      {...props}
+      disabled={disabled || isRecording}
+    >
       <Icon path={mdiMicrophone} className="size-5" />
     </PromptInputButton>
   );

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -647,10 +647,8 @@ function PromptInputHeader({
   ...props
 }: React.ComponentProps<"div">) {
   const { variant, isMultiline, files } = usePromptInputContext();
-  const hideHeader =
-    variant === "floating" && !isMultiline && files.length === 0;
 
-  if (hideHeader) return null;
+  if (files.length === 0) return null;
 
   const floatingSingleLine = variant === "floating" && !isMultiline;
 

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -1342,7 +1342,7 @@ function PromptInputAttachments({
               <Badge
                 colorScheme="neutral"
                 size="lg"
-                className="min-h-7 min-w-12 shrink-0 justify-center overflow-visible!"
+                className="min-h-13 min-w-12 shrink-0 justify-center overflow-visible!"
               >
                 +{overflowCount}
               </Badge>

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -3,6 +3,12 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -20,6 +26,7 @@ import {
   mdiClose,
   mdiFileOutline,
   mdiMicrophone,
+  mdiPaperclip,
   mdiPlus,
   mdiSquare,
 } from "@mdi/js";
@@ -900,27 +907,96 @@ function PromptInputButton({
 }
 
 // ---------------------------------------------------------------------------
-// PromptInputAttachButton (+ icon)
+// PromptInputAttachButton (+ icon → attach menu dropdown)
 // ---------------------------------------------------------------------------
+
+export type PromptInputAttachMenuRenderArgs = {
+  openFileDialog: () => void;
+};
+
+export type PromptInputAttachButtonProps = Omit<
+  PromptInputButtonProps,
+  "onClick"
+> & {
+  /**
+   * Dropdown body for the “+” control. Pass demo/example menus from app
+   * content; when omitted, a single “Attach file” row is shown.
+   */
+  attachMenu?:
+    | ReactNode
+    | ((args: PromptInputAttachMenuRenderArgs) => ReactNode);
+};
 
 function PromptInputAttachButton({
   className,
   tooltip = "Add attachment",
   disabled,
+  attachMenu,
   ...props
-}: Omit<PromptInputButtonProps, "onClick">) {
+}: PromptInputAttachButtonProps) {
   const { openFileDialog, isRecording } = usePromptInputContext();
+  const blocked = Boolean(disabled || isRecording);
+
+  const tooltipProps =
+    typeof tooltip === "string" ? { content: tooltip } : tooltip;
+
+  const menuContent =
+    attachMenu === undefined ? (
+      <DropdownMenuItem
+        className="gap-3 py-2.5 pr-2 pl-2.5 [&>svg:first-child]:size-[18px] [&>svg:first-child]:text-muted-foreground"
+        onSelect={() => {
+          openFileDialog();
+        }}
+      >
+        <Icon path={mdiPaperclip} className="shrink-0" />
+        <span className="min-w-0 flex-1 font-normal">Attach file</span>
+      </DropdownMenuItem>
+    ) : typeof attachMenu === "function" ? (
+      attachMenu({ openFileDialog })
+    ) : (
+      attachMenu
+    );
 
   return (
-    <PromptInputButton
-      tooltip={tooltip}
-      onClick={openFileDialog}
-      className={cn("shrink-0", className)}
-      {...props}
-      disabled={disabled || isRecording}
-    >
-      <Icon path={mdiPlus} className="size-5" />
-    </PromptInputButton>
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              data-slot="prompt-input-attach-trigger"
+              className={cn(
+                "text-muted-foreground hover:text-foreground shrink-0",
+                className,
+              )}
+              disabled={blocked}
+              {...props}
+            >
+              <Icon path={mdiPlus} className="size-5" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side={tooltipProps.side ?? "top"}>
+          <span>{tooltipProps.content}</span>
+          {tooltipProps.shortcut && (
+            <kbd className="ml-2 rounded bg-white/20 px-1.5 py-0.5 text-[10px] font-mono">
+              {tooltipProps.shortcut}
+            </kbd>
+          )}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        side="bottom"
+        align="start"
+        sideOffset={6}
+        className="min-w-0 w-[min(100vw-2rem,13rem)] rounded-lg"
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        {menuContent}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -59,9 +59,23 @@ export interface PromptInputFile {
   preview?: string;
 }
 
+/**
+ * Non-file selection (agent / flow / tool / context) chosen from the attach
+ * menu and rendered as an inline chip in the toolbar.
+ */
+export interface PromptInputSelection {
+  id: string;
+  label: string;
+  /** MDI path string for the leading icon tile. */
+  iconPath?: string;
+  /** Tailwind classes for the leading icon tile background. */
+  iconClassName?: string;
+}
+
 export interface PromptInputMessage {
   text: string;
   files?: PromptInputFile[];
+  selections?: PromptInputSelection[];
 }
 
 // ---------------------------------------------------------------------------
@@ -83,6 +97,10 @@ interface PromptInputContextValue {
   multiple?: boolean;
   maxFiles?: number;
   maxFileSize?: number;
+  selections: PromptInputSelection[];
+  addSelection: (selection: PromptInputSelection) => void;
+  removeSelection: (id: string) => void;
+  clearSelections: () => void;
   /** Inline voice capture: waveform in the text area; stop on the submit control. */
   isRecording: boolean;
   recordingDurationSec: number;
@@ -231,6 +249,7 @@ function PromptInput({
   ...props
 }: PromptInputProps) {
   const [files, setFiles] = useState<PromptInputFile[]>([]);
+  const [selections, setSelections] = useState<PromptInputSelection[]>([]);
   const [isMultiline, setIsMultiline] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
   const [recordingDurationSec, setRecordingDurationSec] = useState(0);
@@ -319,6 +338,21 @@ function PromptInput({
     }
     setFiles([]);
   }, [files]);
+
+  const addSelection = useCallback((selection: PromptInputSelection) => {
+    setSelections((prev) => {
+      if (prev.some((s) => s.id === selection.id)) return prev;
+      return [...prev, selection];
+    });
+  }, []);
+
+  const removeSelection = useCallback((id: string) => {
+    setSelections((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  const clearSelections = useCallback(() => {
+    setSelections([]);
+  }, []);
 
   const openFileDialog = useCallback(() => {
     fileInputRef.current?.click();
@@ -478,9 +512,16 @@ function PromptInput({
       e.preventDefault();
       if (isRecording) return;
       const text = textareaRef.current?.value?.trim() ?? "";
-      if (!text && files.length === 0) return;
+      if (!text && files.length === 0 && selections.length === 0) return;
 
-      onSubmit?.({ text, files: files.length > 0 ? files : undefined }, e);
+      onSubmit?.(
+        {
+          text,
+          files: files.length > 0 ? files : undefined,
+          selections: selections.length > 0 ? selections : undefined,
+        },
+        e,
+      );
 
       if (textareaRef.current) {
         textareaRef.current.value = "";
@@ -488,8 +529,9 @@ function PromptInput({
       }
       setIsMultiline(false);
       clearFiles();
+      clearSelections();
     },
-    [files, onSubmit, clearFiles, isRecording],
+    [files, selections, onSubmit, clearFiles, clearSelections, isRecording],
   );
 
   const handleFileInput = useCallback(
@@ -503,8 +545,15 @@ function PromptInput({
   );
 
   const hasFiles = files.length > 0;
+  /**
+   * Floating treats any selection chip the same as wrapped text — the chip
+   * needs the same multiline layout (textarea on top, toolbar row below) so
+   * it has room to render without squashing the textarea on a single row.
+   */
+  const effectiveMultiline =
+    isMultiline || (variant === "floating" && selections.length > 0);
   /** Single-line floating: one horizontal row for toolbar + textarea + actions. */
-  const floatingSingleLine = variant === "floating" && !isMultiline;
+  const floatingSingleLine = variant === "floating" && !effectiveMultiline;
   /** No attachments — entire form is that single row. */
   const floatingPureInline = floatingSingleLine && !hasFiles;
   /** Attachments on first row, then same centered row as `floatingPureInline`. */
@@ -514,7 +563,7 @@ function PromptInput({
     <PromptInputContext.Provider
       value={{
         variant,
-        isMultiline,
+        isMultiline: effectiveMultiline,
         setIsMultiline,
         files,
         addFiles,
@@ -527,6 +576,10 @@ function PromptInput({
         multiple,
         maxFiles,
         maxFileSize,
+        selections,
+        addSelection,
+        removeSelection,
+        clearSelections,
         isRecording,
         recordingDurationSec,
         recordingAnalyser,
@@ -539,7 +592,7 @@ function PromptInput({
       <form
         data-slot="prompt-input"
         data-variant={variant}
-        data-multiline={isMultiline || undefined}
+        data-multiline={effectiveMultiline || undefined}
         onSubmit={handleSubmit}
         data-recording={isRecording || undefined}
         onKeyDown={(e) => {
@@ -786,6 +839,7 @@ function PromptInputFooter({
 }: React.ComponentProps<"div">) {
   const { variant, isMultiline } = usePromptInputContext();
   const floatingSingleLine = variant === "floating" && !isMultiline;
+  const floatingColumn = variant === "floating" && isMultiline;
 
   return (
     <div
@@ -793,6 +847,7 @@ function PromptInputFooter({
       className={cn(
         "flex items-center gap-2",
         floatingSingleLine ? "shrink-0" : "justify-between px-3 pb-3",
+        floatingColumn && "pt-2",
         className,
       )}
       {...props}
@@ -1320,6 +1375,184 @@ function PromptInputAttachments({
 }
 
 // ---------------------------------------------------------------------------
+// PromptInputSelections (inline chips for picked agents/tools/contexts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed chip width — every selection chip occupies the same space so the
+ * `+`, mic, and submit controls on the toolbar row do not shift around as
+ * chips are added/removed. Long labels truncate to fit. Narrower than the
+ * file-attachment badges since this row also has to fit `+`, mic, submit.
+ */
+const PROMPT_INPUT_SELECTION_CHIP_WIDTH_PX = 140;
+
+/** Fixed `+N` overflow chip width so the toolbar footprint is stable. */
+const PROMPT_INPUT_SELECTION_OVERFLOW_WIDTH_PX = 36;
+
+function PromptInputSelectionChip({
+  selection,
+  onRemove,
+}: {
+  selection: PromptInputSelection;
+  onRemove: () => void;
+}) {
+  return (
+    <Badge
+      colorScheme="neutral"
+      size="lg"
+      data-slot="prompt-input-selection-chip"
+      className={cn(
+        "group/selection-chip min-h-7 shrink-0 justify-start gap-1.5 py-1 pl-1 pr-2 text-sm",
+      )}
+      style={{
+        width: PROMPT_INPUT_SELECTION_CHIP_WIDTH_PX,
+        minWidth: PROMPT_INPUT_SELECTION_CHIP_WIDTH_PX,
+      }}
+    >
+      {selection.iconPath ? (
+        <span
+          className={cn(
+            "flex size-5 shrink-0 items-center justify-center rounded text-white",
+            selection.iconClassName ?? "bg-muted-foreground/40",
+          )}
+          aria-hidden
+        >
+          <Icon path={selection.iconPath} className="size-3 text-white" />
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate text-left">
+        {selection.label}
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${selection.label}`}
+        className={cn(
+          "ml-0.5 flex size-4 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity",
+          "group-hover/selection-chip:opacity-100 focus-visible:opacity-100",
+          "hover:bg-foreground/10 hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+      >
+        <Icon path={mdiClose} className="size-3" />
+      </button>
+    </Badge>
+  );
+}
+
+function PromptInputSelectionListRow({
+  selection,
+  onRemove,
+}: {
+  selection: PromptInputSelection;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-muted/50">
+      {selection.iconPath ? (
+        <span
+          className={cn(
+            "flex size-6 shrink-0 items-center justify-center rounded text-white",
+            selection.iconClassName ?? "bg-muted-foreground/40",
+          )}
+          aria-hidden
+        >
+          <Icon path={selection.iconPath} className="size-3.5 text-white" />
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate">{selection.label}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="shrink-0 rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        aria-label={`Remove ${selection.label}`}
+      >
+        <Icon path={mdiClose} className="size-3" />
+      </button>
+    </div>
+  );
+}
+
+/** Default visible chips before overflowing into a `+N` popover. */
+export const PROMPT_INPUT_MAX_VISIBLE_SELECTIONS = 2;
+
+export interface PromptInputSelectionsProps
+  extends React.ComponentProps<"div"> {
+  maxDisplayItems?: number;
+}
+
+function PromptInputSelections({
+  maxDisplayItems = PROMPT_INPUT_MAX_VISIBLE_SELECTIONS,
+  className,
+  ...props
+}: PromptInputSelectionsProps) {
+  const { selections, removeSelection } = usePromptInputContext();
+
+  if (selections.length === 0) return null;
+
+  const visibleSelections = selections.slice(0, maxDisplayItems);
+  const overflowCount = selections.length - maxDisplayItems;
+
+  return (
+    <div
+      data-slot="prompt-input-selections"
+      className={cn("flex min-w-0 flex-nowrap items-center gap-1.5", className)}
+      {...props}
+    >
+      {visibleSelections.map((s) => (
+        <PromptInputSelectionChip
+          key={s.id}
+          selection={s}
+          onRemove={() => removeSelection(s.id)}
+        />
+      ))}
+      {overflowCount > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="shrink-0 cursor-pointer"
+              aria-label={`Show ${overflowCount} more ${
+                overflowCount === 1 ? "selection" : "selections"
+              }`}
+            >
+              <Badge
+                colorScheme="neutral"
+                size="lg"
+                className="min-h-7 shrink-0 justify-center"
+                style={{
+                  width: PROMPT_INPUT_SELECTION_OVERFLOW_WIDTH_PX,
+                  minWidth: PROMPT_INPUT_SELECTION_OVERFLOW_WIDTH_PX,
+                }}
+              >
+                +{overflowCount}
+              </Badge>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            side="top"
+            className="max-h-60 w-72 overflow-y-auto p-2"
+          >
+            <p className="px-1 pb-2 text-xs font-medium text-muted-foreground">
+              All selections ({selections.length})
+            </p>
+            <div className="flex flex-col gap-1">
+              {selections.map((s) => (
+                <PromptInputSelectionListRow
+                  key={s.id}
+                  selection={s}
+                  onRemove={() => removeSelection(s.id)}
+                />
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // PromptInputMicButton
 // ---------------------------------------------------------------------------
 
@@ -1364,6 +1597,7 @@ export {
   PromptInputAttachButton,
   PromptInputSubmit,
   PromptInputAttachments,
+  PromptInputSelections,
   PromptInputMicButton,
   usePromptInputContext,
 };

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -1,0 +1,946 @@
+"use client"; // Remove this line if you are not using Next.js
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Icon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import {
+  mdiArrowUp,
+  mdiClose,
+  mdiFileOutline,
+  mdiMicrophone,
+  mdiPlus,
+  mdiSquare,
+} from "@mdi/js";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import type * as React from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PromptInputVariant = "default" | "floating";
+
+export type PromptInputStatus = "ready" | "submitted" | "streaming" | "error";
+
+export interface PromptInputFile {
+  id: string;
+  file: File;
+  preview?: string;
+}
+
+export interface PromptInputMessage {
+  text: string;
+  files?: PromptInputFile[];
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface PromptInputContextValue {
+  variant: PromptInputVariant;
+  isMultiline: boolean;
+  setIsMultiline: (v: boolean) => void;
+  files: PromptInputFile[];
+  addFiles: (files: FileList | File[]) => void;
+  removeFile: (id: string) => void;
+  clearFiles: () => void;
+  openFileDialog: () => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  accept?: string;
+  multiple?: boolean;
+  maxFiles?: number;
+  maxFileSize?: number;
+}
+
+const PromptInputContext = createContext<PromptInputContextValue | null>(null);
+
+function usePromptInputContext() {
+  const ctx = useContext(PromptInputContext);
+  if (!ctx) {
+    throw new Error(
+      "PromptInput compound components must be used within <PromptInput>",
+    );
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function generateFileId() {
+  return `file-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function autoResize(el: HTMLTextAreaElement) {
+  el.style.height = "auto";
+  el.style.height = `${el.scrollHeight}px`;
+}
+
+const SINGLE_LINE_HEIGHT = 32;
+
+/** Matches `PromptInputAttachments` default `maxDisplayItems` and fixed badge width. */
+export const PROMPT_INPUT_MAX_VISIBLE_ATTACHMENTS = 3;
+
+/** Fixed file-badge width (px). */
+export const PROMPT_INPUT_ATTACHMENT_BADGE_WIDTH_PX = 160;
+
+/** Header `px-3` (12px × 2) + 3 fixed badges + 3× `gap-1.5` + overflow chip `min-w-12`. */
+export const PROMPT_INPUT_FORM_MIN_WIDTH_PX =
+  24 +
+  PROMPT_INPUT_MAX_VISIBLE_ATTACHMENTS *
+    PROMPT_INPUT_ATTACHMENT_BADGE_WIDTH_PX +
+  3 * 6 +
+  48;
+
+// ---------------------------------------------------------------------------
+// PromptInput (root)
+// ---------------------------------------------------------------------------
+
+export interface PromptInputProps
+  extends Omit<React.ComponentProps<"form">, "onSubmit" | "onError"> {
+  variant?: PromptInputVariant;
+  onSubmit?: (message: PromptInputMessage, event: FormEvent) => void;
+  accept?: string;
+  multiple?: boolean;
+  maxFiles?: number;
+  maxFileSize?: number;
+  onError?: (err: {
+    code: "max_files" | "max_file_size" | "accept";
+    message: string;
+  }) => void;
+}
+
+function PromptInput({
+  variant = "default",
+  onSubmit,
+  accept,
+  multiple = true,
+  maxFiles,
+  maxFileSize,
+  onError,
+  className,
+  children,
+  style,
+  ...props
+}: PromptInputProps) {
+  const [files, setFiles] = useState<PromptInputFile[]>([]);
+  const [isMultiline, setIsMultiline] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const addFiles = useCallback(
+    (incoming: FileList | File[]) => {
+      const newFiles = Array.from(incoming);
+
+      for (const f of newFiles) {
+        if (accept) {
+          const accepted = accept.split(",").map((t) => t.trim());
+          const matches = accepted.some((pattern) => {
+            if (pattern.endsWith("/*")) {
+              return f.type.startsWith(pattern.replace("/*", "/"));
+            }
+            return f.type === pattern || f.name.endsWith(pattern);
+          });
+          if (!matches) {
+            onError?.({
+              code: "accept",
+              message: `File "${f.name}" is not an accepted type`,
+            });
+            return;
+          }
+        }
+        if (maxFileSize && f.size > maxFileSize) {
+          onError?.({
+            code: "max_file_size",
+            message: `File "${f.name}" exceeds maximum size`,
+          });
+          return;
+        }
+      }
+
+      setFiles((prev) => {
+        const combined = [
+          ...prev,
+          ...newFiles.map((file) => {
+            const entry: PromptInputFile = { id: generateFileId(), file };
+            if (file.type.startsWith("image/")) {
+              entry.preview = URL.createObjectURL(file);
+            }
+            return entry;
+          }),
+        ];
+
+        if (maxFiles && combined.length > maxFiles) {
+          onError?.({
+            code: "max_files",
+            message: `Maximum ${maxFiles} files allowed`,
+          });
+          return prev;
+        }
+        return combined;
+      });
+    },
+    [accept, maxFileSize, maxFiles, onError],
+  );
+
+  const removeFile = useCallback((id: string) => {
+    setFiles((prev) => {
+      const file = prev.find((f) => f.id === id);
+      if (file?.preview) URL.revokeObjectURL(file.preview);
+      return prev.filter((f) => f.id !== id);
+    });
+  }, []);
+
+  const clearFiles = useCallback(() => {
+    for (const f of files) {
+      if (f.preview) URL.revokeObjectURL(f.preview);
+    }
+    setFiles([]);
+  }, [files]);
+
+  const openFileDialog = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const text = textareaRef.current?.value?.trim() ?? "";
+      if (!text && files.length === 0) return;
+
+      onSubmit?.({ text, files: files.length > 0 ? files : undefined }, e);
+
+      if (textareaRef.current) {
+        textareaRef.current.value = "";
+        autoResize(textareaRef.current);
+      }
+      setIsMultiline(false);
+      clearFiles();
+    },
+    [files, onSubmit, clearFiles],
+  );
+
+  const handleFileInput = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        addFiles(e.target.files);
+        e.target.value = "";
+      }
+    },
+    [addFiles],
+  );
+
+  const hasFiles = files.length > 0;
+  const isFloatingInline = variant === "floating" && !isMultiline && !hasFiles;
+
+  return (
+    <PromptInputContext.Provider
+      value={{
+        variant,
+        isMultiline,
+        setIsMultiline,
+        files,
+        addFiles,
+        removeFile,
+        clearFiles,
+        openFileDialog,
+        fileInputRef,
+        textareaRef,
+        accept,
+        multiple,
+        maxFiles,
+        maxFileSize,
+      }}
+    >
+      <form
+        data-slot="prompt-input"
+        data-variant={variant}
+        data-multiline={isMultiline || undefined}
+        onSubmit={handleSubmit}
+        className={cn(
+          "group/prompt-input relative bg-white dark:bg-input/30 border transition-shadow",
+          "focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/50",
+          variant === "default" && "flex flex-col w-full rounded-xl",
+          isFloatingInline &&
+            "flex flex-row items-center gap-2 w-full max-w-2xl rounded-xl shadow-lg px-3 py-2",
+          variant === "floating" &&
+            !isFloatingInline &&
+            "flex flex-col w-full max-w-2xl rounded-xl shadow-lg",
+          className,
+        )}
+        style={{
+          minWidth: PROMPT_INPUT_FORM_MIN_WIDTH_PX,
+          ...style,
+        }}
+        {...props}
+      >
+        {children}
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          accept={accept}
+          multiple={multiple}
+          onChange={handleFileInput}
+          tabIndex={-1}
+        />
+      </form>
+    </PromptInputContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputHeader
+// ---------------------------------------------------------------------------
+
+function PromptInputHeader({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { variant, isMultiline, files } = usePromptInputContext();
+  const isFloatingInline =
+    variant === "floating" && !isMultiline && files.length === 0;
+
+  if (isFloatingInline) return null;
+
+  return (
+    <div
+      data-slot="prompt-input-header"
+      className={cn("px-3 pt-3", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputBody
+// ---------------------------------------------------------------------------
+
+function PromptInputBody({ className, ...props }: React.ComponentProps<"div">) {
+  const { variant, isMultiline, files } = usePromptInputContext();
+  const isFloatingInline =
+    variant === "floating" && !isMultiline && files.length === 0;
+
+  return (
+    <div
+      data-slot="prompt-input-body"
+      className={cn(
+        "flex-1",
+        isFloatingInline ? "min-w-0" : "px-4",
+        variant === "floating" && !isFloatingInline && "pt-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputTextarea
+// ---------------------------------------------------------------------------
+
+export interface PromptInputTextareaProps
+  extends Omit<React.ComponentProps<"textarea">, "onKeyDown"> {
+  minHeight?: number;
+  maxHeight?: number;
+  onKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+}
+
+function PromptInputTextarea({
+  className,
+  minHeight,
+  maxHeight = 200,
+  placeholder = "Type anything...",
+  onKeyDown,
+  ...props
+}: PromptInputTextareaProps) {
+  const { textareaRef, variant, setIsMultiline, isMultiline } =
+    usePromptInputContext();
+  const id = useId();
+  const inlineWidthRef = useRef(0);
+
+  const resolvedMinHeight = minHeight ?? (variant === "floating" ? 24 : 40);
+  const resolvedMaxHeight = variant === "floating" ? 120 : maxHeight;
+
+  useLayoutEffect(() => {
+    if (variant === "floating" && textareaRef.current) {
+      const el = textareaRef.current;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, resolvedMaxHeight)}px`;
+    }
+  }, [variant, textareaRef, resolvedMaxHeight]);
+
+  const handleInput = useCallback(
+    (e: React.FormEvent<HTMLTextAreaElement>) => {
+      const el = e.currentTarget;
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, resolvedMaxHeight)}px`;
+
+      if (variant === "floating") {
+        if (!isMultiline) {
+          if (el.offsetWidth > 0) {
+            inlineWidthRef.current = el.offsetWidth;
+          }
+          if (el.scrollHeight > SINGLE_LINE_HEIGHT) {
+            setIsMultiline(true);
+          }
+        } else if (inlineWidthRef.current > 0) {
+          const savedWidth = el.style.width;
+          el.style.width = `${inlineWidthRef.current}px`;
+          el.style.height = "auto";
+          const heightAtInlineWidth = el.scrollHeight;
+          el.style.width = savedWidth;
+          el.style.height = "auto";
+          el.style.height = `${Math.min(el.scrollHeight, resolvedMaxHeight)}px`;
+
+          if (heightAtInlineWidth <= SINGLE_LINE_HEIGHT) {
+            setIsMultiline(false);
+          }
+        }
+      }
+    },
+    [resolvedMaxHeight, variant, setIsMultiline, isMultiline],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        e.currentTarget.form?.requestSubmit();
+      }
+      onKeyDown?.(e);
+    },
+    [onKeyDown],
+  );
+
+  return (
+    <Textarea
+      ref={textareaRef}
+      id={id}
+      data-slot="prompt-input-textarea"
+      rows={1}
+      placeholder={placeholder}
+      className={cn(
+        "w-full resize-none border-0 bg-transparent shadow-none ring-0 focus:ring-0 focus-visible:ring-0 focus-visible:border-0 rounded-none min-h-0 overflow-y-auto px-0",
+        variant === "default" && "py-3",
+        variant === "floating" && "py-0",
+        className,
+      )}
+      style={{
+        minHeight: `${resolvedMinHeight}px`,
+        maxHeight: `${resolvedMaxHeight}px`,
+      }}
+      onInput={handleInput}
+      onKeyDown={handleKeyDown}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputFooter
+// ---------------------------------------------------------------------------
+
+function PromptInputFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const { variant, isMultiline, files } = usePromptInputContext();
+  const isFloatingInline =
+    variant === "floating" && !isMultiline && files.length === 0;
+
+  return (
+    <div
+      data-slot="prompt-input-footer"
+      className={cn(
+        "flex items-center gap-2",
+        isFloatingInline ? "shrink-0" : "justify-between px-3 pb-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputToolbar
+// ---------------------------------------------------------------------------
+
+interface PromptInputToolbarProps extends React.ComponentProps<"div"> {
+  /**
+   * When true, this toolbar is only visible in the floating variant's
+   * single-line (inline) layout. When false (default), it is visible in
+   * the multiline layout (and always visible in the default variant).
+   */
+  inline?: boolean;
+}
+
+function PromptInputToolbar({
+  inline = false,
+  className,
+  ...props
+}: PromptInputToolbarProps) {
+  const { variant, isMultiline, files } = usePromptInputContext();
+  const isFloatingColumn = isMultiline || files.length > 0;
+
+  if (variant === "floating") {
+    if (inline && isFloatingColumn) return null;
+    if (!inline && !isFloatingColumn) return null;
+  } else if (inline) {
+    return null;
+  }
+
+  return (
+    <div
+      data-slot="prompt-input-toolbar"
+      className={cn("flex items-center gap-2 shrink-0", className)}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputActions (right-side actions: mic, submit, etc.)
+// ---------------------------------------------------------------------------
+
+function PromptInputActions({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="prompt-input-actions"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputButton
+// ---------------------------------------------------------------------------
+
+export interface PromptInputButtonProps
+  extends React.ComponentProps<typeof Button> {
+  tooltip?:
+    | string
+    | {
+        content: ReactNode;
+        shortcut?: string;
+        side?: "top" | "right" | "bottom" | "left";
+      };
+}
+
+function PromptInputButton({
+  tooltip,
+  className,
+  ...props
+}: PromptInputButtonProps) {
+  const button = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      data-slot="prompt-input-button"
+      className={cn("text-muted-foreground hover:text-foreground", className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) return button;
+
+  const tooltipProps =
+    typeof tooltip === "string" ? { content: tooltip } : tooltip;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent side={tooltipProps.side ?? "top"}>
+        <span>{tooltipProps.content}</span>
+        {tooltipProps.shortcut && (
+          <kbd className="ml-2 rounded bg-white/20 px-1.5 py-0.5 text-[10px] font-mono">
+            {tooltipProps.shortcut}
+          </kbd>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputAttachButton (+ icon)
+// ---------------------------------------------------------------------------
+
+function PromptInputAttachButton({
+  className,
+  tooltip = "Add attachment",
+  ...props
+}: Omit<PromptInputButtonProps, "onClick">) {
+  const { openFileDialog } = usePromptInputContext();
+
+  return (
+    <PromptInputButton
+      tooltip={tooltip}
+      onClick={openFileDialog}
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      <Icon path={mdiPlus} className="size-5" />
+    </PromptInputButton>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputSubmit
+// ---------------------------------------------------------------------------
+
+export interface PromptInputSubmitProps
+  extends React.ComponentProps<typeof Button> {
+  status?: PromptInputStatus;
+}
+
+function PromptInputSubmit({
+  status = "ready",
+  className,
+  disabled,
+  ...props
+}: PromptInputSubmitProps) {
+  const isStreaming = status === "submitted" || status === "streaming";
+
+  return (
+    <Button
+      type={isStreaming ? "button" : "submit"}
+      variant="default"
+      size="icon-sm"
+      data-slot="prompt-input-submit"
+      disabled={disabled}
+      className={cn("shrink-0", className)}
+      {...props}
+    >
+      {isStreaming ? (
+        <Icon path={mdiSquare} className="size-3" />
+      ) : (
+        <Icon path={mdiArrowUp} className="size-5" />
+      )}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputAttachments (file badges with overflow)
+// ---------------------------------------------------------------------------
+
+type AttachmentDocKind = "pdf" | "word" | "other";
+
+function formatAttachmentSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function getAttachmentDocKind(file: File): AttachmentDocKind {
+  const n = file.name.toLowerCase();
+  const t = file.type.toLowerCase();
+  if (t === "application/pdf" || n.endsWith(".pdf")) return "pdf";
+  if (
+    t === "application/msword" ||
+    t ===
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+    n.endsWith(".doc") ||
+    n.endsWith(".docx")
+  ) {
+    return "word";
+  }
+  return "other";
+}
+
+function isAttachmentImage(file: File, hasPreview: boolean): boolean {
+  return file.type.startsWith("image/") && Boolean(hasPreview);
+}
+
+function PdfAttachmentIcon({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center rounded bg-red-600 text-[9px] font-bold uppercase leading-none tracking-tight text-white",
+        className,
+      )}
+      aria-hidden
+    >
+      PDF
+    </span>
+  );
+}
+
+function WordAttachmentIcon({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center rounded bg-blue-600 text-sm font-bold leading-none text-white",
+        className,
+      )}
+      aria-hidden
+    >
+      W
+    </span>
+  );
+}
+
+function AttachmentDocLeadingIcon({ kind }: { kind: AttachmentDocKind }) {
+  if (kind === "pdf") return <PdfAttachmentIcon />;
+  if (kind === "word") return <WordAttachmentIcon />;
+  return (
+    <span className="flex size-8 shrink-0 items-center justify-center rounded border bg-muted">
+      <Icon path={mdiFileOutline} className="size-4 text-muted-foreground" />
+    </span>
+  );
+}
+
+function AttachmentRemoveControl({
+  fileName,
+  onRemove,
+  className,
+}: {
+  fileName: string;
+  onRemove: () => void;
+  className?: string;
+}) {
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      className={cn(
+        "shrink-0 cursor-pointer rounded-full p-0.5 hover:bg-neutral-bg-active inline-flex items-center justify-center pointer-events-auto text-neutral-fg focus:outline-none focus:ring-1 focus:ring-ring",
+        className,
+      )}
+      onClick={onRemove}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onRemove();
+        }
+      }}
+      aria-label={`Remove ${fileName}`}
+    >
+      <Icon path={mdiClose} className="size-3 pointer-events-none" />
+    </span>
+  );
+}
+
+function PromptInputAttachmentBadge({
+  entry,
+  onRemove,
+}: {
+  entry: PromptInputFile;
+  onRemove: () => void;
+}) {
+  const { file, preview } = entry;
+  if (isAttachmentImage(file, Boolean(preview))) {
+    return (
+      <div
+        className="relative size-13 shrink-0 overflow-visible"
+        data-slot="prompt-input-attachment-chip"
+      >
+        <div className="size-13 overflow-hidden rounded-lg border bg-muted">
+          <img src={preview} alt="" className="size-full object-cover" />
+        </div>
+        <AttachmentRemoveControl
+          fileName={file.name}
+          onRemove={onRemove}
+          className="absolute -right-1 -top-1 border bg-background shadow-sm"
+        />
+      </div>
+    );
+  }
+
+  const docKind = getAttachmentDocKind(file);
+  return (
+    <Badge
+      colorScheme="neutral"
+      size="lg"
+      className="min-h-13 shrink-0 gap-2 overflow-visible! py-1.5"
+      style={{ width: PROMPT_INPUT_ATTACHMENT_BADGE_WIDTH_PX }}
+      data-slot="prompt-input-attachment-chip"
+    >
+      <AttachmentDocLeadingIcon kind={docKind} />
+      <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 leading-tight">
+        <span className="truncate text-xs font-medium">{file.name}</span>
+        <span className="text-[10px] text-muted-foreground">
+          {formatAttachmentSize(file.size)}
+        </span>
+      </div>
+      <AttachmentRemoveControl fileName={file.name} onRemove={onRemove} />
+    </Badge>
+  );
+}
+
+function PromptInputAttachmentListRow({
+  entry,
+  onRemove,
+}: {
+  entry: PromptInputFile;
+  onRemove: () => void;
+}) {
+  const { file, preview } = entry;
+  return (
+    <div className="flex items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-muted/50">
+      {isAttachmentImage(file, Boolean(preview)) ? (
+        <img
+          src={preview}
+          alt=""
+          className="size-13 shrink-0 rounded-lg border border-border object-cover"
+        />
+      ) : (
+        <AttachmentDocLeadingIcon kind={getAttachmentDocKind(file)} />
+      )}
+      <div className="min-w-0 flex-1">
+        <span className="block truncate">{file.name}</span>
+        {!isAttachmentImage(file, Boolean(preview)) && (
+          <span className="text-[10px] text-muted-foreground">
+            {formatAttachmentSize(file.size)}
+          </span>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="shrink-0 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        aria-label={`Remove ${file.name}`}
+      >
+        <Icon path={mdiClose} className="size-3" />
+      </button>
+    </div>
+  );
+}
+
+export interface PromptInputAttachmentsProps
+  extends React.ComponentProps<"div"> {
+  maxDisplayItems?: number;
+}
+
+function PromptInputAttachments({
+  maxDisplayItems = PROMPT_INPUT_MAX_VISIBLE_ATTACHMENTS,
+  className,
+  ...props
+}: PromptInputAttachmentsProps) {
+  const { files, removeFile } = usePromptInputContext();
+
+  if (files.length === 0) return null;
+
+  const visibleFiles = files.slice(0, maxDisplayItems);
+  const overflowCount = files.length - maxDisplayItems;
+
+  return (
+    <div
+      data-slot="prompt-input-attachments"
+      className={cn("flex flex-nowrap items-center gap-1.5 pt-3", className)}
+      {...props}
+    >
+      {visibleFiles.map((f) => (
+        <PromptInputAttachmentBadge
+          key={f.id}
+          entry={f}
+          onRemove={() => removeFile(f.id)}
+        />
+      ))}
+      {overflowCount > 0 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button type="button" className="shrink-0 cursor-pointer">
+              <Badge
+                colorScheme="neutral"
+                size="lg"
+                className="min-h-7 min-w-12 shrink-0 justify-center overflow-visible!"
+              >
+                +{overflowCount}
+              </Badge>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            side="top"
+            className="w-72 max-h-60 overflow-y-auto p-2"
+          >
+            <p className="text-xs font-medium text-muted-foreground px-1 pb-2">
+              All attachments ({files.length})
+            </p>
+            <div className="flex flex-col gap-1">
+              {files.map((f) => (
+                <PromptInputAttachmentListRow
+                  key={f.id}
+                  entry={f}
+                  onRemove={() => removeFile(f.id)}
+                />
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PromptInputMicButton
+// ---------------------------------------------------------------------------
+
+function PromptInputMicButton({
+  className,
+  tooltip = "Voice input",
+  ...props
+}: PromptInputButtonProps) {
+  return (
+    <PromptInputButton tooltip={tooltip} className={className} {...props}>
+      <Icon path={mdiMicrophone} className="size-5" />
+    </PromptInputButton>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+export {
+  PromptInput,
+  PromptInputHeader,
+  PromptInputBody,
+  PromptInputTextarea,
+  PromptInputFooter,
+  PromptInputToolbar,
+  PromptInputActions,
+  PromptInputButton,
+  PromptInputAttachButton,
+  PromptInputSubmit,
+  PromptInputAttachments,
+  PromptInputMicButton,
+  usePromptInputContext,
+};

--- a/src/components/bloks/prompt-input.tsx
+++ b/src/components/bloks/prompt-input.tsx
@@ -257,7 +257,12 @@ function PromptInput({
   );
 
   const hasFiles = files.length > 0;
-  const isFloatingInline = variant === "floating" && !isMultiline && !hasFiles;
+  /** Single-line floating: one horizontal row for toolbar + textarea + actions. */
+  const floatingSingleLine = variant === "floating" && !isMultiline;
+  /** No attachments — entire form is that single row. */
+  const floatingPureInline = floatingSingleLine && !hasFiles;
+  /** Attachments on first row, then same centered row as `floatingPureInline`. */
+  const floatingAttachmentsRow = floatingSingleLine && hasFiles;
 
   return (
     <PromptInputContext.Provider
@@ -287,10 +292,12 @@ function PromptInput({
           "group/prompt-input relative bg-white dark:bg-input/30 border transition-shadow",
           "focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/50",
           variant === "default" && "flex flex-col w-full rounded-xl",
-          isFloatingInline &&
+          floatingPureInline &&
             "flex flex-row items-center gap-2 w-full max-w-2xl rounded-xl shadow-lg px-3 py-2",
+          floatingAttachmentsRow &&
+            "flex flex-row flex-wrap items-center gap-x-2 gap-y-2 w-full max-w-2xl rounded-xl shadow-lg px-3 pb-2 pt-0",
           variant === "floating" &&
-            !isFloatingInline &&
+            !floatingSingleLine &&
             "flex flex-col w-full max-w-2xl rounded-xl shadow-lg",
           className,
         )}
@@ -325,15 +332,23 @@ function PromptInputHeader({
   ...props
 }: React.ComponentProps<"div">) {
   const { variant, isMultiline, files } = usePromptInputContext();
-  const isFloatingInline =
+  const hideHeader =
     variant === "floating" && !isMultiline && files.length === 0;
 
-  if (isFloatingInline) return null;
+  if (hideHeader) return null;
+
+  const floatingSingleLine = variant === "floating" && !isMultiline;
 
   return (
     <div
       data-slot="prompt-input-header"
-      className={cn("px-3 pt-3", className)}
+      className={cn(
+        "pt-3",
+        floatingSingleLine && files.length > 0
+          ? "w-full min-w-full shrink-0 basis-full px-0"
+          : "px-3",
+        className,
+      )}
       {...props}
     >
       {children}
@@ -346,17 +361,16 @@ function PromptInputHeader({
 // ---------------------------------------------------------------------------
 
 function PromptInputBody({ className, ...props }: React.ComponentProps<"div">) {
-  const { variant, isMultiline, files } = usePromptInputContext();
-  const isFloatingInline =
-    variant === "floating" && !isMultiline && files.length === 0;
+  const { variant, isMultiline } = usePromptInputContext();
+  const floatingSingleLine = variant === "floating" && !isMultiline;
 
   return (
     <div
       data-slot="prompt-input-body"
       className={cn(
         "flex-1",
-        isFloatingInline ? "min-w-0" : "px-4",
-        variant === "floating" && !isFloatingInline && "pt-3",
+        floatingSingleLine ? "min-w-0" : "px-4",
+        variant === "floating" && !floatingSingleLine && "pt-3",
         className,
       )}
       {...props}
@@ -474,16 +488,15 @@ function PromptInputFooter({
   className,
   ...props
 }: React.ComponentProps<"div">) {
-  const { variant, isMultiline, files } = usePromptInputContext();
-  const isFloatingInline =
-    variant === "floating" && !isMultiline && files.length === 0;
+  const { variant, isMultiline } = usePromptInputContext();
+  const floatingSingleLine = variant === "floating" && !isMultiline;
 
   return (
     <div
       data-slot="prompt-input-footer"
       className={cn(
         "flex items-center gap-2",
-        isFloatingInline ? "shrink-0" : "justify-between px-3 pb-3",
+        floatingSingleLine ? "shrink-0" : "justify-between px-3 pb-3",
         className,
       )}
       {...props}
@@ -509,8 +522,9 @@ function PromptInputToolbar({
   className,
   ...props
 }: PromptInputToolbarProps) {
-  const { variant, isMultiline, files } = usePromptInputContext();
-  const isFloatingColumn = isMultiline || files.length > 0;
+  const { variant, isMultiline } = usePromptInputContext();
+  /** Only multiline floating moves the + button to the footer toolbar. */
+  const isFloatingColumn = isMultiline;
 
   if (variant === "floating") {
     if (inline && isFloatingColumn) return null;
@@ -787,18 +801,22 @@ function PromptInputAttachmentBadge({
     <Badge
       colorScheme="neutral"
       size="lg"
-      className="min-h-13 shrink-0 gap-2 overflow-visible! py-1.5"
+      className="relative min-h-13 shrink-0 gap-2 overflow-visible! py-1.5"
       style={{ width: PROMPT_INPUT_ATTACHMENT_BADGE_WIDTH_PX }}
       data-slot="prompt-input-attachment-chip"
     >
       <AttachmentDocLeadingIcon kind={docKind} />
-      <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 leading-tight">
+      <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5 pr-5 leading-tight">
         <span className="truncate text-xs font-medium">{file.name}</span>
         <span className="text-[10px] text-muted-foreground">
           {formatAttachmentSize(file.size)}
         </span>
       </div>
-      <AttachmentRemoveControl fileName={file.name} onRemove={onRemove} />
+      <AttachmentRemoveControl
+        fileName={file.name}
+        onRemove={onRemove}
+        className="absolute -right-1 -top-1 z-10 border bg-background shadow-sm"
+      />
     </Badge>
   );
 }

--- a/src/components/component-thumbs/prompt-input.tsx
+++ b/src/components/component-thumbs/prompt-input.tsx
@@ -1,0 +1,57 @@
+const PromptInputThumb = ({ className }: { className?: string }) => (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 400 300"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    preserveAspectRatio="xMidYMid meet"
+  >
+    {/* Input container */}
+    <rect
+      x="60"
+      y="110"
+      width="280"
+      height="80"
+      rx="12"
+      fill="white"
+      stroke="#E5E5E5"
+      strokeWidth="1.5"
+    />
+
+    {/* Placeholder text lines */}
+    <rect x="80" y="130" width="140" height="8" rx="4" fill="#D8D8D8" />
+    <rect
+      x="80"
+      y="144"
+      width="90"
+      height="8"
+      rx="4"
+      fill="#D8D8D8"
+      opacity="0.5"
+    />
+
+    {/* Toolbar area — bottom of input */}
+    {/* Attach button */}
+    <rect x="76" y="164" width="20" height="20" rx="5" fill="#F7F7F7" />
+    <path
+      d="M83 178l3-3a2 2 0 012.8 0l.4.4a2 2 0 010 2.8l-3 3"
+      stroke="#8E8E8E"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+
+    {/* Submit button */}
+    <rect x="306" y="164" width="22" height="20" rx="5" fill="#6E3FFF" />
+    <path
+      d="M317 178l0-8m0 0l-3 3m3-3l3 3"
+      stroke="white"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default PromptInputThumb;

--- a/src/components/docsite/component-thumb-loader.tsx
+++ b/src/components/docsite/component-thumb-loader.tsx
@@ -43,6 +43,7 @@ import PinInputThumb from "@/components/component-thumbs/pin-input";
 import PinnedSiteThumb from "@/components/component-thumbs/pinned-site";
 import PopoverThumb from "@/components/component-thumbs/popover";
 import ProgressThumb from "@/components/component-thumbs/progress";
+import PromptInputThumb from "@/components/component-thumbs/prompt-input";
 import RadioThumb from "@/components/component-thumbs/radio";
 import RadioGroupThumb from "@/components/component-thumbs/radio-group";
 import ResizableThumb from "@/components/component-thumbs/resizable";
@@ -107,6 +108,7 @@ const componentThumbnails: Record<
   "navigation-menu": NavigationMenuThumb,
   pagination: PaginationThumb,
   popover: PopoverThumb,
+  "prompt-input": PromptInputThumb,
   progress: ProgressThumb,
   radio: RadioThumb,
   "radio-group": RadioGroupThumb,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import { type VariantProps, cva } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
-import { Slot } from "radix-ui";
-import * as React from "react";
-
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -24,6 +19,10 @@ import {
 } from "@/components/ui/tooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
+import { type VariantProps, cva } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+import { Slot } from "radix-ui";
+import * as React from "react";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -176,6 +176,7 @@ import DashboardWidgetWhiteBgLargeDemo from "@/app/content/bloks/dashboard-widge
 import PinnedSitesSectionDemo from "@/app/content/bloks/pinned-site-section";
 import PromptInputDemo from "@/app/content/bloks/prompt-input";
 import PromptInputFloatingDemo from "@/app/content/bloks/prompt-input-floating";
+import PromptInputQuestionsDemo from "@/app/content/bloks/prompt-input-questions";
 import PromptInputQueuedDemo from "@/app/content/bloks/prompt-input-queued";
 import SidebarRHSDemo from "@/app/content/bloks/sidebar-rhs";
 import SidebarRHSBriefDemo from "@/app/content/bloks/sidebar-rhs-brief";
@@ -1369,6 +1370,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "prompt-input-queued",
     path: "src/app/content/bloks/prompt-input-queued.tsx",
     component: PromptInputQueuedDemo,
+  },
+  "prompt-input-questions": {
+    name: "prompt-input-questions",
+    path: "src/app/content/bloks/prompt-input-questions.tsx",
+    component: PromptInputQuestionsDemo,
   },
   "sidebar-rhs": {
     name: "sidebar-rhs",

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -174,6 +174,8 @@ import DashboardWidgetGrayBgLargeDemo from "@/app/content/bloks/dashboard-widget
 import DashboardWidgetWhiteBgLargeDemo from "@/app/content/bloks/dashboard-widget-white-bg-large";
 
 import PinnedSitesSectionDemo from "@/app/content/bloks/pinned-site-section";
+import PromptInputDemo from "@/app/content/bloks/prompt-input";
+import PromptInputFloatingDemo from "@/app/content/bloks/prompt-input-floating";
 import SidebarRHSDemo from "@/app/content/bloks/sidebar-rhs";
 import SidebarRHSBriefDemo from "@/app/content/bloks/sidebar-rhs-brief";
 import SidebarRHSBriefTypeDemo from "@/app/content/bloks/sidebar-rhs-brief-type";
@@ -1339,6 +1341,16 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "pinned-site",
     path: "src/app/content/bloks/pinned-site-section.tsx",
     component: PinnedSitesSectionDemo,
+  },
+  "prompt-input": {
+    name: "prompt-input",
+    path: "src/app/content/bloks/prompt-input.tsx",
+    component: PromptInputDemo,
+  },
+  "prompt-input-floating": {
+    name: "prompt-input-floating",
+    path: "src/app/content/bloks/prompt-input-floating.tsx",
+    component: PromptInputFloatingDemo,
   },
   "sidebar-rhs": {
     name: "sidebar-rhs",

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -176,6 +176,7 @@ import DashboardWidgetWhiteBgLargeDemo from "@/app/content/bloks/dashboard-widge
 import PinnedSitesSectionDemo from "@/app/content/bloks/pinned-site-section";
 import PromptInputDemo from "@/app/content/bloks/prompt-input";
 import PromptInputFloatingDemo from "@/app/content/bloks/prompt-input-floating";
+import PromptInputQueuedDemo from "@/app/content/bloks/prompt-input-queued";
 import SidebarRHSDemo from "@/app/content/bloks/sidebar-rhs";
 import SidebarRHSBriefDemo from "@/app/content/bloks/sidebar-rhs-brief";
 import SidebarRHSBriefTypeDemo from "@/app/content/bloks/sidebar-rhs-brief-type";
@@ -1363,6 +1364,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "prompt-input-floating",
     path: "src/app/content/bloks/prompt-input-floating.tsx",
     component: PromptInputFloatingDemo,
+  },
+  "prompt-input-queued": {
+    name: "prompt-input-queued",
+    path: "src/app/content/bloks/prompt-input-queued.tsx",
+    component: PromptInputQueuedDemo,
   },
   "sidebar-rhs": {
     name: "sidebar-rhs",

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -654,6 +654,19 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
         "https://www.figma.com/design/x0CUbrC5Kjcuk64VPCnbgz/Blok-Components?m=auto&node-id=7069-16457&t=NScvPldB3fxBBWL8-1",
     },
   },
+  "prompt-input": {
+    links: {},
+    sections: [
+      { id: "preview", title: "Preview" },
+      { id: "installation", title: "Installation" },
+      { id: "usage", title: "Usage" },
+      {
+        id: "examples",
+        title: "Examples",
+        children: [{ id: "prompt-input-floating", title: "Floating" }],
+      },
+    ],
+  },
   "radio-group": {
     links: {
       shadcn: "https://ui.shadcn.com/docs/components/radio-group",

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -668,6 +668,7 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
         children: [
           { id: "prompt-input-floating", title: "Floating" },
           { id: "prompt-input-queued", title: "Queued" },
+          { id: "prompt-input-questions", title: "Questions" },
         ],
       },
     ],

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -665,7 +665,10 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
       {
         id: "examples",
         title: "Examples",
-        children: [{ id: "prompt-input-floating", title: "Floating" }],
+        children: [
+          { id: "prompt-input-floating", title: "Floating" },
+          { id: "prompt-input-queued", title: "Queued" },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds a new **Prompt Input** blok to the registry — a composable, AI‑chat–style input with attachments, voice‑recording UI, agent/tool selections, and submit/streaming states.

## Description

**What changed**

- **New blok component**: `src/components/bloks/prompt-input.tsx` — a context‑driven, slot‑based composition:
  - `PromptInput`, `PromptInputBody`, `PromptInputHeader`, `PromptInputTextarea`, `PromptInputAttachments`, `PromptInputSelections`, `PromptInputToolbar`, `PromptInputAttachButton`, `PromptInputMicButton`, `PromptInputSubmit`, `PromptInputFooter`, `PromptInputActions`, plus `usePromptInputContext`.
  - Supports `default` and `floating` variants, `ready | submitted | streaming | error` statuses, controlled/uncontrolled value, auto‑resizing textarea, file attachments with previews, non‑file selection chips, drag‑and‑drop, paste‑to‑attach, and an inline voice‑recording UI.
- **Demo content**:
  - `src/app/content/bloks/prompt-input.tsx` — default (chatbot) example with attach menu, agent/tool selections, mic, and submit.
  - `src/app/content/bloks/prompt-input-floating.tsx` — floating/canvas variant.
  - `src/app/content/bloks/prompt-input-queued.tsx` — queued prompts example.
  - `src/app/content/bloks/prompt-input-questions.tsx` — suggested‑questions example.
- **Demo metadata & docs wiring**:
  - `src/app/demo/[name]/bloks/prompt-input.tsx` — usage snippet and variant entries (Floating / Queued / Questions).
  - `src/app/demo/[name]/index.tsx`, `src/components/component-thumbs/prompt-input.tsx`, `src/components/docsite/component-thumb-loader.tsx` — thumbnail and demo registration.
  - `src/lib/docsite/docsite-registry.ts` — registers all four entries (`prompt-input`, `prompt-input-floating`, `prompt-input-queued`, `prompt-input-questions`).
  - `src/lib/right-sidebar-metadata.ts` — adds the right‑sidebar `Examples` section for the three variants.
- **Registry**: `registries/registry.json` — new `prompt-input` block entry depending on `theme`, `badge`, `button`, `tooltip`, `popover`, and `textarea`, plus `@mdi/js`.
- **Minor**: small `src/components/ui/sidebar.tsx` tweak for sidebar positioning interaction with the floating variant.

**Design / tradeoff notes**

- Built around a single React context (`usePromptInputContext`) so the toolbar, attachments, selections, and submit button stay decoupled and consumer‑composable instead of being hardcoded into a monolithic component.
- Voice recording is currently a **UI‑only** affordance (start/stop, timer, waveform placeholder) — no `MediaRecorder` integration. This keeps the blok dependency‑free and lets product teams plug in their own recording/transcription pipeline.
- `textarea` was added as a registry dependency because the auto‑resizing textarea is reused rather than re‑implemented inline.

## Related issue

- Related: #651

## Testing instructions

1. `npm install` then `npm run dev`.
2. Open the docs site and navigate to **Bloks → Prompt input** (`/bloks/prompt-input`).
3. On the default example verify:
   - Typing auto‑resizes the textarea; `Enter` submits, `Shift+Enter` inserts a newline.
   - The attach (`+`) menu opens; selecting an agent/tool/context renders an inline chip with a close button.
   - The paperclip button opens a file picker; dragging files onto the input or pasting an image attaches them; each attachment renders a badge with a remove button.
   - The mic button switches the input into the recording UI; stopping returns to the normal input.
   - While `status="streaming"` the submit button shows a stop (square) icon, and disables on `submitted`.
4. Open the **Floating** example and confirm the variant styling and that it interacts correctly with the right sidebar.
5. Open the **Queued** and **Questions** examples and confirm they render and submit as expected.
6. Vercel preview: https://blok-shadcn-git-dev-sitecoretechnicalmarketing.vercel.app → `/bloks/prompt-input`.
7. Run `npm run lint` and confirm no new Biome issues in changed files.

## Checklist

- [x] **`npm run lint`** (Biome) passes—no new lint issues in changed files
- [x] **Biome formatting** is applied where needed (`npm run lint:fix` and/or `npm run format` so style stays consistent)
- [x] Code follows the project style guidelines
- [x] Self-reviewed the code changes
- [x] Comments added for non-obvious parts of the code
- [x] No new warnings or errors introduced
- [x] Dependent changes merged or published
