### PR TITLE
[Imp]: Accessibility, usage content update, and installation tab UX

### DIFF
--- a/src/app/demo/[name]/ui/action-bar.tsx
+++ b/src/app/demo/[name]/ui/action-bar.tsx
@@ -6,7 +6,7 @@ export const actionBar = {
   usage: {
     usage: [
       `import { ActionBar } from "@/components/ui/action-bar";`,
-      `<ActionBar />`,
+      `<ActionBar \n  isOpen={true}\n/>`,
     ],
   },
 };

--- a/src/app/demo/[name]/ui/button.tsx
+++ b/src/app/demo/[name]/ui/button.tsx
@@ -6,7 +6,7 @@ export const button = {
   usage: {
     usage: [
       `import { Button } from "@/components/ui/button"`,
-      `<Button variant=’default’ colorScheme=’default’ size=’default’>Click me</Button>`,
+      `<Button>Click me</Button>`,
     ],
   },
   components: {

--- a/src/app/demo/[name]/ui/checkbox.tsx
+++ b/src/app/demo/[name]/ui/checkbox.tsx
@@ -6,7 +6,7 @@ export const checkbox = {
   usage: {
     usage: [
       `import { Checkbox } from "@/components/ui/checkbox"`,
-      `<Checkbox id="terms" aria-label="Accept terms and conditions" />`,
+      `<Checkbox id="terms" />`,
     ],
   },
   components: {

--- a/src/app/demo/[name]/ui/stack-navigation.tsx
+++ b/src/app/demo/[name]/ui/stack-navigation.tsx
@@ -7,8 +7,6 @@ export const stackNavigation = {
     usage: [
       `import { StackNavigation } from "@/components/ui/stack-navigation";`,
       `<StackNavigation items={items} />`,
-      `<StackNavigation items={items} colorScheme="neutral" />`,
-      `<StackNavigation items={items} colorScheme="primary" />`,
     ],
   },
   components: {

--- a/src/components/docsite/installation-code-block.tsx
+++ b/src/components/docsite/installation-code-block.tsx
@@ -7,8 +7,16 @@ import { mdiClipboardOutline } from "@mdi/js";
 import Icon from "@mdi/react";
 import { Check } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
+
+const INSTALLATION_PM_STORAGE_KEY = "blok:docsite-installation-pm";
+const PACKAGE_MANAGERS = ["pnpm", "npm", "yarn", "bun"] as const;
+type PackageManager = (typeof PACKAGE_MANAGERS)[number];
+
+function isPackageManager(value: string): value is PackageManager {
+  return (PACKAGE_MANAGERS as readonly string[]).includes(value);
+}
 
 interface InstallationCodeBlockProps {
   registryUrl: string;
@@ -22,7 +30,19 @@ export default function InstallationCodeBlock({
 }: InstallationCodeBlockProps) {
   const pathname = usePathname();
   const [copied, setCopied] = useState(false);
-  const [activeTab, setActiveTab] = useState("pnpm");
+  const [activeTab, setActiveTab] = useState<PackageManager>("pnpm");
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(INSTALLATION_PM_STORAGE_KEY);
+      if (stored && isPackageManager(stored)) {
+        setActiveTab(stored);
+      }
+    } catch {
+      setActiveTab("pnpm");
+      localStorage.setItem(INSTALLATION_PM_STORAGE_KEY, "pnpm");
+    }
+  }, []);
 
   const npxCommand = `npx shadcn@latest add ${registryUrl}`;
   const pnpmCommand = `pnpm dlx shadcn@latest add ${registryUrl}`;
@@ -64,7 +84,13 @@ export default function InstallationCodeBlock({
   };
 
   const handleTabChange = (value: string) => {
+    if (!isPackageManager(value)) return;
     setActiveTab(value);
+    try {
+      localStorage.setItem(INSTALLATION_PM_STORAGE_KEY, value);
+    } catch {
+      // ignore
+    }
     const payload: Record<string, unknown> = { package_manager: value };
     if (componentName && pathname) {
       if (pathname.startsWith("/primitives/")) {
@@ -78,7 +104,7 @@ export default function InstallationCodeBlock({
 
   return (
     <div dir="ltr" className="rounded-lg bg-subtle-bg p-4">
-      <Tabs defaultValue="pnpm" onValueChange={handleTabChange}>
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
         <div className="flex items-center justify-between">
           <TabsList variant="soft-rounded">
             <TabsTrigger

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -572,6 +572,7 @@ const FilterSingleSelect = React.forwardRef<
           >
             <SelectTrigger
               ref={ref}
+              aria-label={ariaLabels?.popoverTrigger ?? placeholder}
               aria-describedby={describedBy}
               className={cn(
                 "*:data-[slot=select-value]:hidden",


### PR DESCRIPTION
## Description
### Accessibility
- Addresses **critical accessibility** issues (focus, semantics, and patterns that blocked or confused AT users). Landed via [#691](https://github.com/Sitecore/blok/pull/691).
### Usage
- **Usage** content and presentation updated so instructions and references match current behavior and are easier to scan. Landed via [#688](https://github.com/Sitecore/blok/pull/688), with follow-up tweaks to the usage section where needed.
### Installation tab
- **Installation tab UX** refined: clearer flow, layout, and interaction for installing or configuring components. Landed via [#690](https://github.com/Sitecore/blok/pull/690), with additional installation-tab polish as needed.
### Filters
- **Filters** expose better **labels and ARIA** so screen readers and keyboard users get meaningful names and relationships for filter UI.
## Related
- [#688](https://github.com/Sitecore/blok/pull/688) — Update Usage  
- [#690](https://github.com/Sitecore/blok/pull/690) — Installation Tab UX  
- [#691](https://github.com/Sitecore/blok/pull/691) — Critical Accessibility Issues  
## Testing instructions
1. **Usage** — Open the usage area; verify copy, structure, and links.
2. **Installation** — Use the installation tab end-to-end; confirm steps and controls feel clear and consistent.
3. **Filters** — With keyboard and a screen reader, confirm filters are announced with correct names and state.
4. **Regression** — Re-check primary flows touched by the accessibility fixes in #691.
## Reviewers
@sc-ishankalakshan
## Checklist
- [X] `npm run lint` (Biome) passes—no new lint issues in changed files  
- [X] Biome formatting applied where needed (`npm run lint:fix` and/or `npm run format`)  
- [X] Code follows the project style guidelines  
- [X] Self-reviewed the code changes  
- [X] Comments added for non-obvious parts of the code  
- [X] No new warnings or errors introduced  