### PR TITLE
[eh]: Accessibility, usage content update, and installation tab UX enhacement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -676,7 +676,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -861,7 +860,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -875,7 +873,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -898,7 +895,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -921,7 +917,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -938,7 +933,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -955,7 +949,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -972,7 +965,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -989,7 +981,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1006,7 +997,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1023,7 +1013,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1040,7 +1029,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1057,7 +1045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1074,7 +1061,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1091,7 +1077,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1114,7 +1099,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1137,7 +1121,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1160,7 +1143,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1183,7 +1165,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1206,7 +1187,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1229,7 +1209,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1252,7 +1231,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1275,7 +1253,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1295,7 +1272,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1315,7 +1291,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1335,7 +1310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1423,7 +1397,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1440,7 +1413,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1457,7 +1429,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1474,7 +1445,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1491,7 +1461,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1508,7 +1477,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1525,7 +1493,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1542,7 +1509,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4489,7 +4455,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6709,7 +6675,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -6723,7 +6688,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-hook-form": "^7.60.0",
     "react-resizable-panels": "^3.0.3",
     "react-select": "^5.10.2",
+    "react-window": "^2.2.7",
     "recharts": "^2.15.4",
     "shiki": "^3.15.0",
     "sonner": "^2.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-select:
         specifier: ^5.10.2
         version: 5.10.2(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-window:
+        specifier: ^2.2.7
+        version: 2.2.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       recharts:
         specifier: ^2.15.4
         version: 2.15.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -2464,6 +2467,12 @@ packages:
     peerDependencies:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
+
+  react-window@2.2.7:
+    resolution: {integrity: sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -5083,6 +5092,11 @@ snapshots:
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  react-window@2.2.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 

--- a/src/app/(registry)/graphics/icons/page.tsx
+++ b/src/app/(registry)/graphics/icons/page.tsx
@@ -822,6 +822,7 @@ export default function IconsPage() {
                               });
                             }}
                             className="cursor-pointer inline-flex items-center justify-center w-8 h-8 hover:bg-muted rounded transition-colors"
+                            aria-label={`Copy icon code for ${icon}`}
                           >
                             <Icon
                               path={path}

--- a/src/app/content/bloks/dashboard-widget-white-bg-large.tsx
+++ b/src/app/content/bloks/dashboard-widget-white-bg-large.tsx
@@ -43,7 +43,11 @@ export default function DashboardWidgetWhiteBgLargeDemo() {
             options={filterOptions}
             placeholder="Filter"
             className="w-fit"
-            aria-label="Select an option"
+            ariaLabels={{
+              popoverTrigger: "Select an option",
+              listbox: "List of options",
+              clearSelection: "Clear selection",
+            }}
           />
         </DashboardWidgetToolbar>
         <DashboardWidgetContent>

--- a/src/app/content/bloks/prompt-input-floating.tsx
+++ b/src/app/content/bloks/prompt-input-floating.tsx
@@ -587,7 +587,10 @@ function FloatingChatCard() {
           <PromptInputAttachments />
         </PromptInputHeader>
         <PromptInputToolbar inline>
-          <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+          <PromptInputAttachButton
+            aria-label="add attachment"
+            attachMenu={promptInputDemoAttachMenu}
+          />
           <PromptInputSelections />
         </PromptInputToolbar>
         <PromptInputBody>
@@ -595,12 +598,15 @@ function FloatingChatCard() {
         </PromptInputBody>
         <PromptInputFooter>
           <PromptInputToolbar>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
-            <PromptInputMicButton />
-            <PromptInputSubmit />
+            <PromptInputMicButton aria-label="record voice input" />
+            <PromptInputSubmit aria-label="submit prompt" />
           </PromptInputActions>
         </PromptInputFooter>
       </PromptInput>
@@ -635,7 +641,10 @@ export default function PromptInputFloatingDemo() {
           </PromptInputHeader>
           {/* Visible only when single-line (inline layout) */}
           <PromptInputToolbar inline>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputBody>
@@ -644,12 +653,15 @@ export default function PromptInputFloatingDemo() {
           <PromptInputFooter>
             {/* Visible only when multiline (column layout) */}
             <PromptInputToolbar>
-              <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+              <PromptInputAttachButton
+                aria-label="add attachment"
+                attachMenu={promptInputDemoAttachMenu}
+              />
               <PromptInputSelections />
             </PromptInputToolbar>
             <PromptInputActions>
-              <PromptInputMicButton />
-              <PromptInputSubmit />
+              <PromptInputMicButton aria-label="record voice input" />
+              <PromptInputSubmit aria-label="submit prompt" />
             </PromptInputActions>
           </PromptInputFooter>
         </PromptInput>

--- a/src/app/content/bloks/prompt-input-questions.tsx
+++ b/src/app/content/bloks/prompt-input-questions.tsx
@@ -591,7 +591,10 @@ function QuestionPromptCard({
         </PromptInputHeader>
         {variant === "floating" && (
           <PromptInputToolbar inline>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
         )}
@@ -600,12 +603,15 @@ function QuestionPromptCard({
         </PromptInputBody>
         <PromptInputFooter>
           <PromptInputToolbar>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
-            <PromptInputMicButton />
-            <PromptInputSubmit />
+            <PromptInputMicButton aria-label="record voice input" />
+            <PromptInputSubmit aria-label="submit prompt" />
           </PromptInputActions>
         </PromptInputFooter>
       </PromptInput>

--- a/src/app/content/bloks/prompt-input-questions.tsx
+++ b/src/app/content/bloks/prompt-input-questions.tsx
@@ -534,7 +534,7 @@ function QuestionPromptCard({
 
           <p className="text-sm text-foreground">{question}</p>
 
-          <ul
+          <div
             role="radiogroup"
             aria-label="Question answers"
             className="flex flex-col gap-2"
@@ -543,7 +543,7 @@ function QuestionPromptCard({
               const letter = String.fromCharCode(65 + index);
               const isSelected = selectedId === answer.id;
               return (
-                <li key={answer.id} className="min-w-0">
+                <div key={answer.id} className="min-w-0">
                   <button
                     type="button"
                     role="radio"
@@ -560,10 +560,10 @@ function QuestionPromptCard({
                     <span className="shrink-0">{letter}.</span>
                     <span className="min-w-0 truncate">{answer.label}</span>
                   </button>
-                </li>
+                </div>
               );
             })}
-          </ul>
+          </div>
         </div>
       )}
 

--- a/src/app/content/bloks/prompt-input-queued.tsx
+++ b/src/app/content/bloks/prompt-input-queued.tsx
@@ -579,7 +579,10 @@ function QueuedPromptCard({
         </PromptInputHeader>
         {variant === "floating" && (
           <PromptInputToolbar inline>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
         )}
@@ -588,11 +591,14 @@ function QueuedPromptCard({
         </PromptInputBody>
         <PromptInputFooter>
           <PromptInputToolbar>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
-            <PromptInputMicButton />
+            <PromptInputMicButton aria-label="record voice input" />
             <PromptInputSubmit
               status={isProcessing ? "streaming" : "ready"}
               onClick={(e) => {
@@ -601,6 +607,7 @@ function QueuedPromptCard({
                   setIsProcessing(false);
                 }
               }}
+              aria-label="submit prompt"
             />
           </PromptInputActions>
         </PromptInputFooter>

--- a/src/app/content/bloks/prompt-input.tsx
+++ b/src/app/content/bloks/prompt-input.tsx
@@ -528,12 +528,15 @@ export default function PromptInputDemo() {
         </PromptInputBody>
         <PromptInputFooter>
           <PromptInputToolbar>
-            <PromptInputAttachButton attachMenu={promptInputDemoAttachMenu} />
+            <PromptInputAttachButton
+              aria-label="add attachment"
+              attachMenu={promptInputDemoAttachMenu}
+            />
             <PromptInputSelections />
           </PromptInputToolbar>
           <PromptInputActions>
-            <PromptInputMicButton />
-            <PromptInputSubmit />
+            <PromptInputMicButton aria-label="record voice input" />
+            <PromptInputSubmit aria-label="submit prompt" />
           </PromptInputActions>
         </PromptInputFooter>
       </PromptInput>

--- a/src/app/content/bloks/sidebar-rhs-brief.tsx
+++ b/src/app/content/bloks/sidebar-rhs-brief.tsx
@@ -82,6 +82,7 @@ function OverviewSection() {
             checked={todoChecked}
             onCheckedChange={(checked) => setTodoChecked(checked === true)}
             className="shrink-0"
+            aria-label="Complete todo"
           />
           <span className="text-sm flex-1">
             <Badge size="sm" colorScheme="neutral" className="mr-1">
@@ -106,6 +107,7 @@ function OverviewSection() {
             checked={newTodoChecked}
             onCheckedChange={(checked) => setNewTodoChecked(checked === true)}
             className="shrink-0"
+            aria-label="Add new todo"
           />
           <Input
             type="text"

--- a/src/app/content/bloks/sidebar-rhs-component.tsx
+++ b/src/app/content/bloks/sidebar-rhs-component.tsx
@@ -112,6 +112,7 @@ function OverviewSection() {
           />
           <Input
             type="text"
+            autoComplete="off"
             placeholder="Add new to-do, type @ to mention someone"
             className="flex-1 border-0 bg-transparent px-0 py-0 h-auto text-sm placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
           />

--- a/src/app/content/bloks/sidebar-rhs-content.tsx
+++ b/src/app/content/bloks/sidebar-rhs-content.tsx
@@ -401,13 +401,10 @@ function StatisticsSection() {
       <div className="grid grid-cols-[auto_auto] gap-4">
         {/* Total Variants */}
         <div className="flex flex-col gap-1 min-w-0">
-          <label
-            htmlFor="total-variants"
-            className="text-xs uppercase text-muted-foreground"
-          >
+          <span className="text-xs uppercase text-muted-foreground">
             Total Variants
-          </label>
-          <div id="total-variants" className="flex items-baseline gap-2">
+          </span>
+          <div className="flex items-baseline gap-2">
             <span className="text-2xl font-bold text-foreground shrink-0">
               18
             </span>
@@ -432,15 +429,8 @@ function StatisticsSection() {
 
         {/* Sites */}
         <div className="flex flex-col gap-1 shrink-0">
-          <label
-            htmlFor="sites"
-            className="text-xs uppercase text-muted-foreground"
-          >
-            Sites
-          </label>
-          <span id="sites" className="text-2xl font-bold text-foreground">
-            3
-          </span>
+          <span className="text-xs uppercase text-muted-foreground">Sites</span>
+          <span className="text-2xl font-bold text-foreground">3</span>
         </div>
       </div>
     </div>

--- a/src/app/content/bloks/sidebar-rhs-heading-with-tabs.tsx
+++ b/src/app/content/bloks/sidebar-rhs-heading-with-tabs.tsx
@@ -112,6 +112,7 @@ function OverviewSection() {
           />
           <Input
             type="text"
+            autoComplete="off"
             placeholder="Add new to-do, type @ to mention someone"
             className="flex-1 border-0 bg-transparent px-0 py-0 h-auto text-sm placeholder:text-muted-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
           />

--- a/src/app/content/bloks/sidebar-rhs-heading-with-tabs.tsx
+++ b/src/app/content/bloks/sidebar-rhs-heading-with-tabs.tsx
@@ -85,6 +85,7 @@ function OverviewSection() {
             checked={todoChecked}
             onCheckedChange={(checked) => setTodoChecked(checked === true)}
             className="shrink-0"
+            aria-label="Complete todo"
           />
           <span className="text-sm flex-1">
             <Badge size="sm" colorScheme="neutral" className="mr-1">
@@ -109,6 +110,7 @@ function OverviewSection() {
             checked={newTodoChecked}
             onCheckedChange={(checked) => setNewTodoChecked(checked === true)}
             className="shrink-0"
+            aria-label="Add new todo"
           />
           <Input
             type="text"

--- a/src/app/content/ui/calendar-multiple.tsx
+++ b/src/app/content/ui/calendar-multiple.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Calendar } from "@/components/ui/calendar";
-import { format, parseISO } from "date-fns";
+import { addDays, format } from "date-fns";
 import * as React from "react";
 import type { DateRange } from "react-day-picker";
 
@@ -9,8 +9,8 @@ export function MultiCalendar({
   numberOfMonths = 1,
 }: { numberOfMonths?: number }) {
   const [dateRange, setDateRange] = React.useState<DateRange | undefined>({
-    from: parseISO("2025-06-09"),
-    to: parseISO("2025-06-26"),
+    from: new Date(),
+    to: addDays(new Date(), 20),
   });
 
   return (

--- a/src/app/content/ui/calendar-multiple.tsx
+++ b/src/app/content/ui/calendar-multiple.tsx
@@ -1,62 +1,9 @@
 "use client";
 
 import { Calendar } from "@/components/ui/calendar";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { format, parseISO } from "date-fns";
 import * as React from "react";
 import type { DateRange } from "react-day-picker";
-import type { DropdownProps } from "react-day-picker";
-
-export function CustomDropdown({
-  options = [],
-  value,
-  onChange,
-  disabled,
-  name,
-  id,
-}: DropdownProps) {
-  return (
-    <Select
-      disabled={disabled}
-      name={name}
-      value={value != null ? String(value) : ""}
-      onValueChange={(val) => {
-        const e = {
-          target: { value: val },
-        } as unknown as React.ChangeEvent<HTMLSelectElement>;
-        onChange?.(e);
-      }}
-    >
-      <SelectTrigger
-        id={id}
-        size="sm"
-        aria-label={value ? undefined : "Select an option"}
-        className="z-50 px-3 text-sm [&_svg:not([class*='text-'])]:text-accent-foreground bg-transparent dark:bg-transparent dark:hover:bg-transparent"
-      >
-        <SelectValue />
-      </SelectTrigger>
-
-      <SelectContent className="rounded-md borde p-0 min-w-20">
-        {options.map(({ value: v, label, disabled }) => (
-          <SelectItem
-            key={String(v)}
-            value={String(v)}
-            disabled={disabled}
-            className="cursor-pointer px-3 py-1.5 text-sm"
-          >
-            {label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
 
 export function MultiCalendar({
   numberOfMonths = 1,
@@ -75,7 +22,6 @@ export function MultiCalendar({
       numberOfMonths={numberOfMonths}
       className="rounded-lg border shadow-sm"
       captionLayout="dropdown"
-      components={{ Dropdown: CustomDropdown }}
       labels={{
         labelDayButton: (day) => {
           const visible = format(day, "d");

--- a/src/app/content/ui/calendar.tsx
+++ b/src/app/content/ui/calendar.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { Calendar } from "@/components/ui/calendar";
-import { format, parseISO } from "date-fns";
+import { format } from "date-fns";
 import * as React from "react";
 
 export default function CalendarDemo() {
-  const [date, setDate] = React.useState<Date | undefined>(
-    parseISO("2025-06-12"),
-  );
+  const [date, setDate] = React.useState<Date | undefined>(() => new Date());
 
   return (
     <Calendar

--- a/src/app/content/ui/calendar.tsx
+++ b/src/app/content/ui/calendar.tsx
@@ -1,62 +1,8 @@
 "use client";
 
 import { Calendar } from "@/components/ui/calendar";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { format, parseISO } from "date-fns";
 import * as React from "react";
-import type { DropdownProps } from "react-day-picker";
-
-export function CustomDropdown({
-  options = [],
-  value,
-  onChange,
-  disabled,
-  name,
-  id,
-  "aria-label": ariaLabel,
-}: DropdownProps) {
-  return (
-    <Select
-      disabled={disabled}
-      name={name}
-      value={value != null ? String(value) : ""}
-      onValueChange={(val) => {
-        const e = {
-          target: { value: val },
-        } as unknown as React.ChangeEvent<HTMLSelectElement>;
-        onChange?.(e);
-      }}
-    >
-      <SelectTrigger
-        id={id}
-        size="sm"
-        aria-label={ariaLabel}
-        className="z-50 px-3 text-sm [&_svg:not([class*='text-'])]:text-accent-foreground bg-transparent dark:bg-transparent dark:hover:bg-transparent"
-      >
-        <SelectValue />
-      </SelectTrigger>
-
-      <SelectContent className="rounded-md borde p-0 min-w-20">
-        {options.map(({ value: v, label, disabled }) => (
-          <SelectItem
-            key={String(v)}
-            value={String(v)}
-            disabled={disabled}
-            className="cursor-pointer px-3 py-1.5 text-sm"
-          >
-            {label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
 
 export default function CalendarDemo() {
   const [date, setDate] = React.useState<Date | undefined>(
@@ -71,7 +17,6 @@ export default function CalendarDemo() {
       onSelect={setDate}
       className="rounded-lg border shadow-sm"
       captionLayout="dropdown"
-      components={{ Dropdown: CustomDropdown }}
       labels={{
         labelDayButton: (day) => {
           const visible = format(day, "d");

--- a/src/app/content/ui/combobox-multiple.tsx
+++ b/src/app/content/ui/combobox-multiple.tsx
@@ -32,11 +32,7 @@ export default function ComboboxMultipleDemo() {
       items={frameworks}
       defaultValue={[frameworks[0]]}
     >
-      <ComboboxChips
-        ref={anchor}
-        className="w-full max-w-xs"
-        aria-label="Combobox chips"
-      >
+      <ComboboxChips ref={anchor} className="w-full max-w-xs">
         <ComboboxValue>
           {(values: readonly string[]) => (
             <React.Fragment>
@@ -45,7 +41,7 @@ export default function ComboboxMultipleDemo() {
                   {value}
                 </ComboboxChip>
               ))}
-              <ComboboxChipsInput />
+              <ComboboxChipsInput aria-label="Combobox chips input" />
             </React.Fragment>
           )}
         </ComboboxValue>

--- a/src/app/content/ui/date-picker-range.tsx
+++ b/src/app/content/ui/date-picker-range.tsx
@@ -2,7 +2,7 @@ import { DatePickerWithRange } from "@/components/ui/date-picker";
 import { addDays } from "date-fns";
 
 export default function DatePickerWithRangeDemo() {
-  const defaultFrom = new Date(new Date().getFullYear(), 0, 20);
+  const defaultFrom = new Date();
   return (
     <DatePickerWithRange
       defaultValue={{

--- a/src/app/content/ui/field-error.tsx
+++ b/src/app/content/ui/field-error.tsx
@@ -28,7 +28,13 @@ export default function FieldWithErrorDemo() {
           </Field>
           <Field data-invalid>
             <FieldLabel htmlFor="field-error-password">Password</FieldLabel>
-            <Input id="field-error-password" type="password" aria-invalid />
+            <Input
+              id="field-error-password"
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              aria-invalid
+            />
             <FieldError
               errors={[
                 { message: "Password must be at least 8 characters" },

--- a/src/app/content/ui/field-input-types.tsx
+++ b/src/app/content/ui/field-input-types.tsx
@@ -44,6 +44,8 @@ export default function FieldInputTypesDemo() {
             <Input
               id="field-email"
               type="email"
+              name="email"
+              autoComplete="email"
               placeholder="email@example.com"
             />
           </Field>

--- a/src/app/content/ui/filter-input.tsx
+++ b/src/app/content/ui/filter-input.tsx
@@ -11,7 +11,7 @@ export default function FilterInputDemo() {
       value={value}
       onChange={setValue}
       placeholder="Search..."
-      ariaLabel="Search"
+      aria-label="Search"
     />
   );
 }

--- a/src/app/content/ui/filter-multi-select.tsx
+++ b/src/app/content/ui/filter-multi-select.tsx
@@ -47,6 +47,11 @@ export default function FilterMultiSelectDemo() {
         options={[]}
         placeholder="Multi-select filter"
         groups={BLOCKCN_FILTER_GROUPS}
+        ariaLabels={{
+          popoverTrigger: "Select options",
+          listbox: "List of options",
+          clearSelection: "Clear all selections",
+        }}
       />
       <FilterMultiSelect
         value={badgeValues}
@@ -55,6 +60,11 @@ export default function FilterMultiSelectDemo() {
         placeholder="Multi-select filter"
         groups={BLOCKCN_FILTER_GROUPS}
         displayMode="badge"
+        ariaLabels={{
+          popoverTrigger: "Select options",
+          listbox: "List of options",
+          clearSelection: "Clear all selections",
+        }}
       />
     </div>
   );

--- a/src/app/content/ui/filter-single-select.tsx
+++ b/src/app/content/ui/filter-single-select.tsx
@@ -46,7 +46,11 @@ export default function FilterSingleSelectDemo() {
         options={[]}
         placeholder="Single select filter"
         groups={BLOCKCN_FILTER_GROUPS}
-        aria-label="Select an option"
+        ariaLabels={{
+          popoverTrigger: "Select an option",
+          listbox: "List of options",
+          clearSelection: "Clear selection",
+        }}
       />
     </div>
   );

--- a/src/app/content/ui/filter-with-avatar.tsx
+++ b/src/app/content/ui/filter-with-avatar.tsx
@@ -64,7 +64,11 @@ export default function FilterWithAvatarDemo() {
         onChange={setSingleValue}
         options={[]}
         placeholder="Single select filter"
-        aria-label="Select an option"
+        ariaLabels={{
+          popoverTrigger: "Select an option",
+          listbox: "List of options",
+          clearSelection: "Clear selection",
+        }}
         groups={BLOCKCN_FILTER_GROUPS}
         searchable
         showSearch={false}
@@ -82,6 +86,11 @@ export default function FilterWithAvatarDemo() {
         showSearch={false}
         noResultsText="No results found"
         renderOption={renderOptionWithAvatar}
+        ariaLabels={{
+          popoverTrigger: "Select options",
+          listbox: "List of options",
+          clearSelection: "Clear all selections",
+        }}
       />
     </div>
   );

--- a/src/app/content/ui/filter-with-search.tsx
+++ b/src/app/content/ui/filter-with-search.tsx
@@ -51,7 +51,12 @@ export default function FilterWithSearchDemo() {
         searchable
         searchPlaceholder="Search"
         noResultsText="No results found"
-        aria-label="Select an option"
+        ariaLabels={{
+          popoverTrigger: "Select an option",
+          searchInput: "Search",
+          listbox: "List of options",
+          clearSelection: "Clear selection",
+        }}
       />
 
       <FilterMultiSelect
@@ -63,6 +68,12 @@ export default function FilterWithSearchDemo() {
         searchable
         searchPlaceholder="Search"
         noResultsText="No results found"
+        ariaLabels={{
+          popoverTrigger: "Select options",
+          searchInput: "Search",
+          listbox: "List of options",
+          clearSelection: "Clear all selections",
+        }}
       />
     </div>
   );

--- a/src/app/content/ui/filter.tsx
+++ b/src/app/content/ui/filter.tsx
@@ -60,6 +60,7 @@ export default function FilterDemo() {
         options: [],
         placeholder: "Single select filter",
         groups: BLOCKCN_FILTER_GROUPS,
+        "aria-label": "Select an option",
       },
     },
     {

--- a/src/app/content/ui/filter.tsx
+++ b/src/app/content/ui/filter.tsx
@@ -60,7 +60,6 @@ export default function FilterDemo() {
         options: [],
         placeholder: "Single select filter",
         groups: BLOCKCN_FILTER_GROUPS,
-        "aria-label": "Select an option",
       },
     },
     {

--- a/src/app/content/ui/filter.tsx
+++ b/src/app/content/ui/filter.tsx
@@ -49,7 +49,7 @@ export default function FilterDemo() {
       key: "search",
       props: {
         placeholder: "Search...",
-        ariaLabel: "Search",
+        "aria-label": "Search",
         width: "w-64",
       },
     },
@@ -60,6 +60,11 @@ export default function FilterDemo() {
         options: [],
         placeholder: "Single select filter",
         groups: BLOCKCN_FILTER_GROUPS,
+        ariaLabels: {
+          popoverTrigger: "Select an option",
+          listbox: "List of options",
+          clearSelection: "Clear selection",
+        },
       },
     },
     {
@@ -69,6 +74,11 @@ export default function FilterDemo() {
         options: [],
         placeholder: "Multi-select filter",
         groups: BLOCKCN_FILTER_GROUPS,
+        ariaLabels: {
+          popoverTrigger: "Select options",
+          listbox: "List of options",
+          clearSelection: "Clear all selections",
+        },
       },
     },
   ];

--- a/src/app/content/ui/input.tsx
+++ b/src/app/content/ui/input.tsx
@@ -8,6 +8,8 @@ export default function InputDemo() {
       <Input
         type="text"
         id="input"
+        name="name"
+        autoComplete="name"
         placeholder="Enter your name"
         aria-label="Name"
       />

--- a/src/app/content/ui/sidebar-icon-combination.tsx
+++ b/src/app/content/ui/sidebar-icon-combination.tsx
@@ -22,7 +22,7 @@ export default function SidebarIconCombinationDemo() {
                   <Icon path={mdiHome} />
                   <span>Home</span>
                 </SidebarMenuButton>
-                <SidebarMenuAction>
+                <SidebarMenuAction aria-label="open home in new tab">
                   <Icon path={mdiOpenInNew} />
                 </SidebarMenuAction>
               </SidebarMenuItem>
@@ -31,7 +31,7 @@ export default function SidebarIconCombinationDemo() {
                   <Icon path={mdiAccount} />
                   <span>Profile</span>
                 </SidebarMenuButton>
-                <SidebarMenuAction>
+                <SidebarMenuAction aria-label="open profile in new tab">
                   <Icon path={mdiOpenInNew} />
                 </SidebarMenuAction>
               </SidebarMenuItem>
@@ -40,7 +40,7 @@ export default function SidebarIconCombinationDemo() {
                   <Icon path={mdiCog} />
                   <span>Settings</span>
                 </SidebarMenuButton>
-                <SidebarMenuAction>
+                <SidebarMenuAction aria-label="open settings in new tab">
                   <Icon path={mdiOpenInNew} />
                 </SidebarMenuAction>
               </SidebarMenuItem>

--- a/src/app/content/ui/sidebar-trailing-icon.tsx
+++ b/src/app/content/ui/sidebar-trailing-icon.tsx
@@ -21,7 +21,7 @@ export default function SidebarTrailingIconDemo() {
                 <SidebarMenuButton isActive>
                   <span>Home</span>
                 </SidebarMenuButton>
-                <SidebarMenuAction>
+                <SidebarMenuAction aria-label="open home in new tab">
                   <Icon path={mdiOpenInNew} />
                 </SidebarMenuAction>
               </SidebarMenuItem>
@@ -29,7 +29,7 @@ export default function SidebarTrailingIconDemo() {
                 <SidebarMenuButton>
                   <span>Profile</span>
                 </SidebarMenuButton>
-                <SidebarMenuAction>
+                <SidebarMenuAction aria-label="open profile in new tab">
                   <Icon path={mdiOpenInNew} />
                 </SidebarMenuAction>
               </SidebarMenuItem>
@@ -37,7 +37,7 @@ export default function SidebarTrailingIconDemo() {
                 <SidebarMenuButton disabled>
                   <span>Settings</span>
                 </SidebarMenuButton>
-                <SidebarMenuAction>
+                <SidebarMenuAction aria-label="open settings in new tab">
                   <Icon path={mdiOpenInNew} />
                 </SidebarMenuAction>
               </SidebarMenuItem>

--- a/src/app/demo/[name]/ui/action-bar.tsx
+++ b/src/app/demo/[name]/ui/action-bar.tsx
@@ -6,7 +6,7 @@ export const actionBar = {
   usage: {
     usage: [
       `import { ActionBar } from "@/components/ui/action-bar";`,
-      `<ActionBar />`,
+      `<ActionBar \n  isOpen={true}\n/>`,
     ],
   },
 };

--- a/src/app/demo/[name]/ui/button.tsx
+++ b/src/app/demo/[name]/ui/button.tsx
@@ -6,7 +6,7 @@ export const button = {
   usage: {
     usage: [
       `import { Button } from "@/components/ui/button"`,
-      `<Button variant=’default’ colorScheme=’default’ size=’default’>Click me</Button>`,
+      `<Button>Click me</Button>`,
     ],
   },
   components: {

--- a/src/app/demo/[name]/ui/checkbox.tsx
+++ b/src/app/demo/[name]/ui/checkbox.tsx
@@ -6,7 +6,7 @@ export const checkbox = {
   usage: {
     usage: [
       `import { Checkbox } from "@/components/ui/checkbox"`,
-      `<Checkbox id="terms" aria-label="Accept terms and conditions" />`,
+      `<Checkbox id="terms" />`,
     ],
   },
   components: {

--- a/src/app/demo/[name]/ui/date-picker.tsx
+++ b/src/app/demo/[name]/ui/date-picker.tsx
@@ -5,8 +5,8 @@ export const datePicker = {
   },
   usage: {
     usage: [
-      `import { Button } from "@/components/ui/button"\nimport { Calendar } from "@/components/ui/calendar"\nimport {\n  Popover,\n  PopoverContent,\n  PopoverTrigger,\n} from "@/components/ui/popover"`,
-      `<Popover>\n  <PopoverTrigger asChild>\n    <Button variant="outline">Pick a date</Button>\n  </PopoverTrigger>\n  <PopoverContent>\n    <Calendar />\n  </PopoverContent>\n</Popover>`,
+      `import { DatePickerSimple } from "@/components/ui/date-picker"`,
+      `<DatePickerSimple />`,
     ],
   },
   components: {

--- a/src/app/demo/[name]/ui/filter.tsx
+++ b/src/app/demo/[name]/ui/filter.tsx
@@ -64,7 +64,7 @@ export default function FilterDemo() {
       key: "search",
       props: {
         placeholder: "Search...",
-        ariaLabel: "Search",
+        "aria-label": "Search",
         width: "w-64",
       },
     },

--- a/src/app/demo/[name]/ui/stack-navigation.tsx
+++ b/src/app/demo/[name]/ui/stack-navigation.tsx
@@ -7,8 +7,6 @@ export const stackNavigation = {
     usage: [
       `import { StackNavigation } from "@/components/ui/stack-navigation";`,
       `<StackNavigation items={items} />`,
-      `<StackNavigation items={items} colorScheme="neutral" />`,
-      `<StackNavigation items={items} colorScheme="primary" />`,
     ],
   },
   components: {

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -157,8 +157,8 @@ export function CodeBlock({
       </div>
       <div
         dir="ltr"
-        className="text-md overflow-x-auto p-4 wrap-break-words"
-        style={{ minWidth: 0, width: "100%" }}
+        className="text-md min-w-0 p-4 wrap-break-words"
+        style={{ width: "100%" }}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     </div>

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -123,8 +123,12 @@ export function CodeBlock({
   return (
     <div
       dir="ltr"
+      role="region"
+      tabIndex={0}
+      aria-label="Code sample"
       className={cn(
         "relative rounded-md bg-muted max-h-[400px] overflow-auto",
+        "outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         className,
       )}
       style={{ width: "100%", maxWidth: "100%" }}

--- a/src/components/docsite/installation-code-block.tsx
+++ b/src/components/docsite/installation-code-block.tsx
@@ -7,8 +7,16 @@ import { mdiClipboardOutline } from "@mdi/js";
 import Icon from "@mdi/react";
 import { Check } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "../ui/button";
+
+const INSTALLATION_PM_STORAGE_KEY = "blok:docsite-installation-pm";
+const PACKAGE_MANAGERS = ["pnpm", "npm", "yarn", "bun"] as const;
+type PackageManager = (typeof PACKAGE_MANAGERS)[number];
+
+function isPackageManager(value: string): value is PackageManager {
+  return (PACKAGE_MANAGERS as readonly string[]).includes(value);
+}
 
 interface InstallationCodeBlockProps {
   registryUrl: string;
@@ -22,7 +30,19 @@ export default function InstallationCodeBlock({
 }: InstallationCodeBlockProps) {
   const pathname = usePathname();
   const [copied, setCopied] = useState(false);
-  const [activeTab, setActiveTab] = useState("pnpm");
+  const [activeTab, setActiveTab] = useState<PackageManager>("pnpm");
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(INSTALLATION_PM_STORAGE_KEY);
+      if (stored && isPackageManager(stored)) {
+        setActiveTab(stored);
+      }
+    } catch {
+      setActiveTab("pnpm");
+      localStorage.setItem(INSTALLATION_PM_STORAGE_KEY, "pnpm");
+    }
+  }, []);
 
   const npxCommand = `npx shadcn@latest add ${registryUrl}`;
   const pnpmCommand = `pnpm dlx shadcn@latest add ${registryUrl}`;
@@ -64,7 +84,13 @@ export default function InstallationCodeBlock({
   };
 
   const handleTabChange = (value: string) => {
+    if (!isPackageManager(value)) return;
     setActiveTab(value);
+    try {
+      localStorage.setItem(INSTALLATION_PM_STORAGE_KEY, value);
+    } catch {
+      // ignore
+    }
     const payload: Record<string, unknown> = { package_manager: value };
     if (componentName && pathname) {
       if (pathname.startsWith("/primitives/")) {
@@ -78,7 +104,7 @@ export default function InstallationCodeBlock({
 
   return (
     <div dir="ltr" className="rounded-lg bg-subtle-bg p-4">
-      <Tabs defaultValue="pnpm" onValueChange={handleTabChange}>
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
         <div className="flex items-center justify-between">
           <TabsList variant="soft-rounded">
             <TabsTrigger

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -5,15 +5,68 @@ import { mdiChevronLeft, mdiChevronRight } from "@mdi/js";
 import { format } from "date-fns";
 import * as React from "react";
 
+import { Button, buttonVariants } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon } from "lucide-react";
 import {
   type DayButton,
   DayPicker,
+  type DropdownProps,
   getDefaultClassNames,
 } from "react-day-picker";
 
-import { Button, buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { ChevronDownIcon } from "lucide-react";
+export function InBuiltDropdown({
+  options = [],
+  value,
+  onChange,
+  disabled,
+  name,
+  id,
+  "aria-label": ariaLabel,
+}: DropdownProps) {
+  return (
+    <Select
+      disabled={disabled}
+      name={name}
+      value={value != null ? String(value) : ""}
+      onValueChange={(val) => {
+        const e = {
+          target: { value: val },
+        } as unknown as React.ChangeEvent<HTMLSelectElement>;
+        onChange?.(e);
+      }}
+    >
+      <SelectTrigger
+        id={id}
+        size="sm"
+        aria-label={ariaLabel}
+        className="z-50 px-3 text-sm [&_svg:not([class*='text-'])]:text-accent-foreground bg-transparent dark:bg-transparent dark:hover:bg-transparent"
+      >
+        <SelectValue />
+      </SelectTrigger>
+
+      <SelectContent className="rounded-md borde p-0 min-w-20">
+        {options.map(({ value: v, label, disabled }) => (
+          <SelectItem
+            key={String(v)}
+            value={String(v)}
+            disabled={disabled}
+            className="cursor-pointer px-3 py-1.5 text-sm"
+          >
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
 
 function Calendar({
   className,
@@ -187,6 +240,7 @@ function Calendar({
             </td>
           );
         },
+        Dropdown: InBuiltDropdown,
         ...components,
       }}
       {...props}

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -30,7 +30,10 @@ type CalendarProps = React.ComponentProps<typeof Calendar>;
  * For DayPicker label creators (nav, days, etc.), use `calendarProps.ariaLabels`.
  */
 export type DatePickerAriaLabels = {
-  /** `aria-label` on the popover trigger button */
+  /**
+   * `aria-label` on the popover trigger when **no date is selected** (empty state).
+   * When a date is shown, `aria-label` is omitted so the visible formatted date is the accessible name.
+   */
   popoverTrigger?: string;
 };
 
@@ -154,8 +157,10 @@ function DatePickerSimple(props: DatePickerSimpleProps) {
           colorScheme="neutral"
           disabled={disabled}
           aria-label={
-            ariaLabels?.popoverTrigger ??
-            (typeof placeholder === "string" ? placeholder : undefined)
+            date
+              ? undefined
+              : (ariaLabels?.popoverTrigger ??
+                (typeof placeholder === "string" ? placeholder : undefined))
           }
           className={cn(
             "border-input border-1 data-[state=open]:border-2 data-[state=open]:border-primary rounded-md text-md data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 bg-body-bg px-3 py-2 whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:opacity-50 h-10",
@@ -279,8 +284,10 @@ function DatePickerWithRange(props: DatePickerWithRangeProps) {
           colorScheme="neutral"
           disabled={disabled}
           aria-label={
-            ariaLabels?.popoverTrigger ??
-            (typeof placeholder === "string" ? placeholder : undefined)
+            range?.from
+              ? undefined
+              : (ariaLabels?.popoverTrigger ??
+                (typeof placeholder === "string" ? placeholder : undefined))
           }
           className={cn(
             "border-input border-1 data-[state=open]:border-2 data-[state=open]:border-primary rounded-md text-md data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 bg-body-bg px-3 py-2 whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[2px] disabled:cursor-not-allowed disabled:opacity-50 h-10",

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -13,15 +13,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
-import type { DropdownProps } from "react-day-picker";
 
 type CalendarProps = React.ComponentProps<typeof Calendar>;
 
@@ -33,50 +25,6 @@ export type DatePickerAriaLabels = {
   /** `aria-label` on the popover trigger button */
   popoverTrigger?: string;
 };
-
-export function CustomDropdown({
-  options = [],
-  value,
-  onChange,
-  disabled,
-  name,
-  id,
-}: DropdownProps) {
-  return (
-    <Select
-      disabled={disabled}
-      name={name}
-      value={value != null ? String(value) : ""}
-      onValueChange={(val) => {
-        const e = {
-          target: { value: val },
-        } as unknown as React.ChangeEvent<HTMLSelectElement>;
-        onChange?.(e);
-      }}
-    >
-      <SelectTrigger
-        id={id}
-        size="sm"
-        className="z-50 px-3 text-sm text-neutral-fg [&_svg:not([class*='text-'])]:text-accent-foreground bg-transparent dark:bg-transparent dark:hover:bg-transparent"
-      >
-        <SelectValue />
-      </SelectTrigger>
-
-      <SelectContent className="rounded-md borde p-0 min-w-20">
-        {options.map(({ value: v, label, disabled }) => (
-          <SelectItem
-            key={String(v)}
-            value={String(v)}
-            disabled={disabled}
-            className="cursor-pointer px-3 py-1.5 text-sm"
-          >
-            {label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
 
 export type DatePickerSimpleCalendarProps = Omit<
   CalendarProps,
@@ -186,7 +134,6 @@ function DatePickerSimple(props: DatePickerSimpleProps) {
           captionLayout={calendarProps?.captionLayout ?? "dropdown"}
           locale={mergedLocale}
           components={{
-            Dropdown: CustomDropdown,
             ...calendarProps?.components,
           }}
         />
@@ -309,7 +256,6 @@ function DatePickerWithRange(props: DatePickerWithRangeProps) {
           captionLayout={calendarProps?.captionLayout ?? "dropdown"}
           locale={mergedLocale}
           components={{
-            Dropdown: CustomDropdown,
             ...calendarProps?.components,
           }}
         />

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -100,7 +100,7 @@ export interface FilterInputProps {
   defaultValue?: string;
   onChange?: (value: string) => void;
   placeholder?: string;
-  ariaLabel?: string;
+  "aria-label"?: string;
   icon?: string;
   showClear?: boolean;
   className?: string;
@@ -133,6 +133,7 @@ export interface FilterSingleSelectProps {
   disabled?: boolean;
   name?: string;
   helperText?: string;
+  ariaLabels?: FilterAriaLabels;
   "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   dropdownClassName?: string;
@@ -159,7 +160,7 @@ export interface FilterMultiSelectProps {
   disabled?: boolean;
   name?: string;
   helperText?: string;
-  "aria-label"?: string;
+  ariaLabels?: FilterAriaLabels;
   renderOption?: (option: FilterOption) => React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -184,6 +185,13 @@ export interface FilterBarProps {
   ariaLabel?: string;
 }
 
+export type FilterAriaLabels = {
+  popoverTrigger?: string;
+  searchInput?: string;
+  listbox?: string;
+  clearSelection?: string;
+};
+
 // FILTER INPUT COMPONENT
 
 const FilterInput = React.forwardRef<
@@ -196,7 +204,7 @@ const FilterInput = React.forwardRef<
       defaultValue = "",
       onChange,
       placeholder = "Search...",
-      ariaLabel = "Search",
+      "aria-label": ariaLabel = "Search",
       icon = mdiMagnify,
       showClear = true,
       className,
@@ -295,6 +303,9 @@ const FilterSingleSelect = React.forwardRef<
       disabled = false,
       name,
       helperText,
+      ariaLabels = {
+        clearSelection: "Clear selection",
+      },
       "aria-describedby": ariaDescribedBy,
       renderOption,
       dropdownClassName,
@@ -389,7 +400,7 @@ const FilterSingleSelect = React.forwardRef<
                   ref={ref}
                   type="button"
                   variant="ghost"
-                  aria-label={placeholder}
+                  aria-label={ariaLabels?.popoverTrigger ?? placeholder}
                   aria-describedby={describedBy}
                   aria-expanded={open}
                   disabled={disabled}
@@ -462,7 +473,9 @@ const FilterSingleSelect = React.forwardRef<
                         placeholder={searchPlaceholder}
                         value={searchQuery}
                         onChange={(e) => setSearchQuery(e.target.value)}
-                        aria-label={searchPlaceholder}
+                        aria-label={
+                          ariaLabels?.searchInput ?? searchPlaceholder
+                        }
                         className="placeholder:text-muted-foreground"
                       />
                       {searchQuery && (
@@ -480,7 +493,9 @@ const FilterSingleSelect = React.forwardRef<
                   <div
                     className="py-0.5"
                     role="listbox"
-                    aria-label={groupLabel || placeholder}
+                    aria-label={
+                      ariaLabels?.listbox ?? groupLabel ?? placeholder
+                    }
                   >
                     {filteredOptions.length === 0 ? (
                       <div className="py-6 text-center text-sm text-muted-foreground">
@@ -525,7 +540,7 @@ const FilterSingleSelect = React.forwardRef<
                 variant="ghost"
                 size="icon-xs"
                 colorScheme="neutral"
-                aria-label="Clear selection"
+                aria-label={ariaLabels?.clearSelection}
                 className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-auto text-neutral-fg hover:bg-neutral-bg-active"
               >
                 <Icon path={mdiClose} size={0.75} />
@@ -641,7 +656,7 @@ const FilterSingleSelect = React.forwardRef<
               variant="ghost"
               size="icon-xs"
               colorScheme="neutral"
-              aria-label="Clear selection"
+              aria-label={ariaLabels?.clearSelection}
               className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-auto text-neutral-fg hover:bg-neutral-bg-active"
             >
               <Icon path={mdiClose} size={0.75} />
@@ -687,6 +702,9 @@ const FilterMultiSelect = React.forwardRef<
       disabled = false,
       name,
       helperText,
+      ariaLabels = {
+        clearSelection: "Clear selection",
+      },
       "aria-describedby": ariaDescribedBy,
       renderOption,
       open: controlledOpen,
@@ -859,6 +877,7 @@ const FilterMultiSelect = React.forwardRef<
                 type="button"
                 variant="ghost"
                 disabled={disabled}
+                aria-label={ariaLabels?.popoverTrigger ?? placeholder}
                 aria-describedby={describedBy}
                 aria-expanded={open}
                 style={
@@ -1027,7 +1046,7 @@ const FilterMultiSelect = React.forwardRef<
                       placeholder={searchPlaceholder}
                       value={searchQuery}
                       onChange={(e) => setSearchQuery(e.target.value)}
-                      aria-label={searchPlaceholder}
+                      aria-label={ariaLabels?.searchInput ?? searchPlaceholder}
                       className="placeholder:text-muted-foreground"
                     />
                     {searchQuery && (
@@ -1045,7 +1064,7 @@ const FilterMultiSelect = React.forwardRef<
                 <div
                   className="py-0.5"
                   role="group"
-                  aria-label={groupLabel || placeholder}
+                  aria-label={ariaLabels?.listbox ?? groupLabel ?? placeholder}
                 >
                   {groups ? (
                     !filteredMultiGroups || filteredMultiGroups.length === 0 ? (
@@ -1089,7 +1108,7 @@ const FilterMultiSelect = React.forwardRef<
               variant="ghost"
               size="icon-xs"
               colorScheme="neutral"
-              aria-label="Clear all selections"
+              aria-label={ariaLabels?.clearSelection}
               className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-auto hover:bg-neutral-bg-active"
             >
               <Icon path={mdiClose} size={0.75} />

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -133,7 +133,6 @@ export interface FilterSingleSelectProps {
   disabled?: boolean;
   name?: string;
   helperText?: string;
-  "aria-label"?: string;
   "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   dropdownClassName?: string;
@@ -161,7 +160,6 @@ export interface FilterMultiSelectProps {
   name?: string;
   helperText?: string;
   "aria-label"?: string;
-  "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -298,7 +296,6 @@ const FilterSingleSelect = React.forwardRef<
       name,
       helperText,
       "aria-describedby": ariaDescribedBy,
-      "aria-label": ariaLabel,
       renderOption,
       dropdownClassName,
       ...props
@@ -392,7 +389,7 @@ const FilterSingleSelect = React.forwardRef<
                   ref={ref}
                   type="button"
                   variant="ghost"
-                  aria-label={ariaLabel ?? placeholder}
+                  aria-label={placeholder}
                   aria-describedby={describedBy}
                   aria-expanded={open}
                   disabled={disabled}
@@ -561,7 +558,6 @@ const FilterSingleSelect = React.forwardRef<
             <SelectTrigger
               ref={ref}
               aria-describedby={describedBy}
-              aria-label={ariaLabel}
               className={cn(
                 "*:data-[slot=select-value]:hidden",
                 FILTER_SELECT_TRIGGER_CLASSNAME,
@@ -692,7 +688,6 @@ const FilterMultiSelect = React.forwardRef<
       name,
       helperText,
       "aria-describedby": ariaDescribedBy,
-      "aria-label": ariaLabel,
       renderOption,
       open: controlledOpen,
       onOpenChange,
@@ -864,7 +859,6 @@ const FilterMultiSelect = React.forwardRef<
                 type="button"
                 variant="ghost"
                 disabled={disabled}
-                aria-label={ariaLabel ?? placeholder}
                 aria-describedby={describedBy}
                 aria-expanded={open}
                 style={

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -133,6 +133,7 @@ export interface FilterSingleSelectProps {
   disabled?: boolean;
   name?: string;
   helperText?: string;
+  "aria-label"?: string;
   "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   dropdownClassName?: string;
@@ -159,6 +160,7 @@ export interface FilterMultiSelectProps {
   disabled?: boolean;
   name?: string;
   helperText?: string;
+  "aria-label"?: string;
   "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   open?: boolean;
@@ -296,6 +298,7 @@ const FilterSingleSelect = React.forwardRef<
       name,
       helperText,
       "aria-describedby": ariaDescribedBy,
+      "aria-label": ariaLabel,
       renderOption,
       dropdownClassName,
       ...props
@@ -389,7 +392,7 @@ const FilterSingleSelect = React.forwardRef<
                   ref={ref}
                   type="button"
                   variant="ghost"
-                  aria-label={placeholder}
+                  aria-label={ariaLabel ?? placeholder}
                   aria-describedby={describedBy}
                   aria-expanded={open}
                   disabled={disabled}
@@ -558,6 +561,7 @@ const FilterSingleSelect = React.forwardRef<
             <SelectTrigger
               ref={ref}
               aria-describedby={describedBy}
+              aria-label={ariaLabel}
               className={cn(
                 "*:data-[slot=select-value]:hidden",
                 FILTER_SELECT_TRIGGER_CLASSNAME,
@@ -688,6 +692,7 @@ const FilterMultiSelect = React.forwardRef<
       name,
       helperText,
       "aria-describedby": ariaDescribedBy,
+      "aria-label": ariaLabel,
       renderOption,
       open: controlledOpen,
       onOpenChange,
@@ -859,6 +864,7 @@ const FilterMultiSelect = React.forwardRef<
                 type="button"
                 variant="ghost"
                 disabled={disabled}
+                aria-label={ariaLabel ?? placeholder}
                 aria-describedby={describedBy}
                 aria-expanded={open}
                 style={

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -136,7 +136,6 @@ export interface FilterSingleSelectProps {
   "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   dropdownClassName?: string;
-  "aria-label"?: string;
 }
 
 export interface FilterMultiSelectProps {
@@ -296,7 +295,6 @@ const FilterSingleSelect = React.forwardRef<
       disabled = false,
       name,
       helperText,
-      "aria-label": ariaLabel,
       "aria-describedby": ariaDescribedBy,
       renderOption,
       dropdownClassName,
@@ -391,7 +389,7 @@ const FilterSingleSelect = React.forwardRef<
                   ref={ref}
                   type="button"
                   variant="ghost"
-                  aria-label={ariaLabel}
+                  aria-label={placeholder}
                   aria-describedby={describedBy}
                   aria-expanded={open}
                   disabled={disabled}

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -572,6 +572,7 @@ const FilterSingleSelect = React.forwardRef<
           >
             <SelectTrigger
               ref={ref}
+              aria-label={ariaLabels?.popoverTrigger ?? placeholder}
               aria-describedby={describedBy}
               className={cn(
                 "*:data-[slot=select-value]:hidden",

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -136,6 +136,7 @@ export interface FilterSingleSelectProps {
   "aria-describedby"?: string;
   renderOption?: (option: FilterOption) => React.ReactNode;
   dropdownClassName?: string;
+  "aria-label"?: string;
 }
 
 export interface FilterMultiSelectProps {
@@ -295,6 +296,7 @@ const FilterSingleSelect = React.forwardRef<
       disabled = false,
       name,
       helperText,
+      "aria-label": ariaLabel,
       "aria-describedby": ariaDescribedBy,
       renderOption,
       dropdownClassName,
@@ -389,7 +391,7 @@ const FilterSingleSelect = React.forwardRef<
                   ref={ref}
                   type="button"
                   variant="ghost"
-                  aria-label={placeholder}
+                  aria-label={ariaLabel}
                   aria-describedby={describedBy}
                   aria-expanded={open}
                   disabled={disabled}

--- a/src/components/ui/select-react.tsx
+++ b/src/components/ui/select-react.tsx
@@ -15,7 +15,9 @@ import ReactSelect, {
   type MultiValueRemoveProps,
   type MultiValueGenericProps,
   type OptionProps,
+  type MenuListProps,
 } from "react-select";
+import { List, type ListImperativeAPI } from "react-window";
 
 import { cn } from "@/lib/utils";
 
@@ -89,7 +91,7 @@ function MultiValueRemove<
 }
 
 // Custom option component with checkmark for selected items
-function CustomOption<
+const CustomOption = React.memo(function CustomOption<
   Option extends SelectReactOption,
   IsMulti extends boolean,
   Group extends GroupBase<Option>,
@@ -131,6 +133,193 @@ function CustomOption<
       </div>
     </components.Option>
   );
+}) as typeof components.Option;
+
+const MENU_VIRTUALIZE_THRESHOLD = 50;
+const MENU_ROW_SINGLE = 40;
+const MENU_ROW_WITH_DESCRIPTION = 64;
+
+type VirtualMenuRowProps = { menuRows: readonly React.ReactNode[] };
+
+function isGroupedOptions<Option>(
+  options: readonly Option[] | unknown,
+): boolean {
+  if (!Array.isArray(options) || options.length === 0) return false;
+  const first = options[0] as { options?: unknown };
+  return (
+    first != null &&
+    typeof first === "object" &&
+    "options" in first &&
+    Array.isArray(first.options)
+  );
+}
+
+function menuRowHeight(child: React.ReactNode): number {
+  if (React.isValidElement(child)) {
+    const data = (child.props as { data?: SelectReactOption }).data;
+    if (data?.description) return MENU_ROW_WITH_DESCRIPTION;
+  }
+  return MENU_ROW_SINGLE;
+}
+
+function totalMenuContentHeight(
+  menuRows: readonly React.ReactNode[],
+  rowHeightFn: (index: number, props: VirtualMenuRowProps) => number,
+  rowProps: VirtualMenuRowProps,
+): number {
+  let sum = 0;
+  for (let i = 0; i < menuRows.length; i++) {
+    sum += rowHeightFn(i, rowProps);
+  }
+  return sum;
+}
+
+type VirtualizedMenuListInnerProps<
+  Option extends SelectReactOption,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+> = MenuListProps<Option, IsMulti, Group> & {
+  items: readonly React.ReactNode[];
+};
+
+/** Holds all list virtualization hooks; only mounted when the menu uses the virtualized path. */
+function VirtualizedMenuListInner<
+  Option extends SelectReactOption,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+>({ items, ...props }: VirtualizedMenuListInnerProps<Option, IsMulti, Group>) {
+  const {
+    maxHeight,
+    innerRef,
+    innerProps,
+    focusedOption,
+    isMulti,
+    cx,
+    getClassNames,
+    className,
+  } = props;
+
+  const rowProps = React.useMemo<VirtualMenuRowProps>(
+    () => ({ menuRows: items }),
+    [items],
+  );
+
+  const rowHeightFn = React.useCallback(
+    (index: number, p: VirtualMenuRowProps) => menuRowHeight(p.menuRows[index]),
+    [],
+  );
+
+  const contentHeight = React.useMemo(
+    () => totalMenuContentHeight(items, rowHeightFn, rowProps),
+    [items, rowHeightFn, rowProps],
+  );
+
+  const listViewportHeight = Math.min(maxHeight, contentHeight);
+
+  const listClassName = cx(
+    { "menu-list": true, "menu-list--is-multi": isMulti },
+    getClassNames("menuList", props),
+    className,
+  );
+
+  const listRef = React.useRef<ListImperativeAPI | null>(null);
+  const innerRefLatest = React.useRef(innerRef);
+  innerRefLatest.current = innerRef;
+
+  const assignMenuListElementRef = React.useCallback(
+    (element: HTMLDivElement | null) => {
+      const ref = innerRefLatest.current;
+      if (typeof ref === "function") {
+        ref(element);
+      } else if (ref && typeof ref === "object" && "current" in ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current =
+          element;
+      }
+    },
+    [],
+  );
+
+  React.useLayoutEffect(() => {
+    assignMenuListElementRef(listRef.current?.element ?? null);
+    return () => assignMenuListElementRef(null);
+  }, [assignMenuListElementRef]);
+
+  React.useLayoutEffect(() => {
+    if (!focusedOption || items.length === 0) return;
+    const index = items.findIndex(
+      (row) =>
+        React.isValidElement(row) &&
+        (row.props as { data?: Option }).data === focusedOption,
+    );
+    if (index < 0) return;
+    queueMicrotask(() => {
+      listRef.current?.scrollToRow({ index, align: "auto" });
+    });
+  }, [focusedOption, items]);
+
+  const rowComponent = React.useCallback(
+    ({
+      index,
+      style,
+      menuRows,
+    }: {
+      ariaAttributes: {
+        "aria-posinset": number;
+        "aria-setsize": number;
+        role: "listitem";
+      };
+      index: number;
+      style: React.CSSProperties;
+    } & VirtualMenuRowProps) => (
+      <div role="presentation" style={style}>
+        {menuRows[index]}
+      </div>
+    ),
+    [],
+  );
+
+  return (
+    <List<VirtualMenuRowProps>
+      {...innerProps}
+      className={cn(listClassName, innerProps.className)}
+      listRef={listRef}
+      onResize={() =>
+        assignMenuListElementRef(listRef.current?.element ?? null)
+      }
+      onRowsRendered={() =>
+        assignMenuListElementRef(listRef.current?.element ?? null)
+      }
+      overscanCount={5}
+      rowComponent={rowComponent}
+      rowCount={items.length}
+      rowHeight={rowHeightFn}
+      rowProps={rowProps}
+      style={{ height: listViewportHeight, width: "100%" }}
+    />
+  );
+}
+
+function VirtualizedMenuList<
+  Option extends SelectReactOption,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+>(props: MenuListProps<Option, IsMulti, Group>) {
+  const { children, selectProps } = props;
+  const items = React.useMemo(
+    () => React.Children.toArray(children),
+    [children],
+  );
+  const options = selectProps.options;
+
+  if (
+    isGroupedOptions(options) ||
+    items.length <= MENU_VIRTUALIZE_THRESHOLD ||
+    items.length === 0
+  ) {
+    return <components.MenuList {...props} />;
+  }
+
+  return <VirtualizedMenuListInner {...props} items={items} />;
 }
 
 function SelectReact<
@@ -148,127 +337,148 @@ function SelectReact<
   // Generate a stable ID to prevent hydration mismatches
   const id = React.useId();
   const selectInstanceId = instanceId ?? id;
-  const classNames: ClassNamesConfig<Option, IsMulti, Group> = {
-    control: ({ isFocused, isDisabled: controlDisabled, menuIsOpen }) =>
-      cn(
-        // Base styles matching SelectTrigger
-        "border-input text-md flex w-full items-center gap-2 rounded-md border-1 px-3 transition-[color] outline-none",
-        // Size variants
-        size === "default" ? "min-h-10" : "min-h-8",
-        // Focus states - only apply ring when focused but menu is closed
-        isFocused && !menuIsOpen && "border-input ring-ring/50 ring-1",
-        // When menu is open, use border-2 (no ring to avoid double border)
-        menuIsOpen && "border-primary border-2",
-        // Disabled state
-        controlDisabled && "cursor-not-allowed opacity-50",
-        // Dark mode
-        "dark:bg-input/30 dark:hover:bg-input/50",
-        // Remove default react-select background
-        "bg-body-bg",
-        className,
-      ),
-    placeholder: () => "text-muted-foreground",
-    input: () => "text-foreground",
-    singleValue: () => "text-foreground",
-    valueContainer: () => "gap-1 p-0",
-    indicatorSeparator: () => "hidden",
-    indicatorsContainer: () => "gap-1",
-    dropdownIndicator: () => "text-muted-foreground p-0",
-    clearIndicator: () => "text-muted-foreground p-0 cursor-pointer",
-    menu: () =>
-      cn(
-        "bg-popover text-popover-foreground relative z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
-        // Animation classes matching SelectContent
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
-      ),
-    menuList: () => "p-1 max-h-[300px]",
-    option: ({ isFocused, isSelected, isDisabled: optionDisabled, data }) =>
-      cn(
-        // Base styles matching SelectItem
-        "relative flex w-full cursor-default gap-2 rounded-sm py-1.5 px-2 !text-sm outline-hidden select-none",
-        data.description ? "items-start" : "items-center",
-        // Hover/focus state
-        isFocused && "bg-accent text-accent-foreground",
-        // Selected state
-        isSelected && "bg-accent text-accent-foreground",
-        // Disabled state
-        optionDisabled && "pointer-events-none opacity-50",
-      ),
-    group: () => "",
-    groupHeading: () =>
-      "text-muted-foreground px-2 py-1.5 text-xs font-semibold uppercase",
-    noOptionsMessage: () => "text-muted-foreground py-6 text-center text-sm",
-    loadingMessage: () => "text-muted-foreground py-6 text-center text-sm",
-    multiValue: () => "",
-    multiValueLabel: () => "text-sm",
-    multiValueRemove: () =>
-      "hover:bg-destructive/20 hover:text-destructive rounded-sm p-0.5 transition-colors cursor-pointer",
-  };
+
+  const classNames = React.useMemo<ClassNamesConfig<Option, IsMulti, Group>>(
+    () => ({
+      control: ({ isFocused, isDisabled: controlDisabled, menuIsOpen }) =>
+        cn(
+          // Base styles matching SelectTrigger
+          "border-input text-md flex w-full items-center gap-2 rounded-md border-1 px-3 transition-[color] outline-none",
+          // Size variants
+          size === "default" ? "min-h-10" : "min-h-8",
+          // Focus states - only apply ring when focused but menu is closed
+          isFocused && !menuIsOpen && "border-input ring-ring/50 ring-1",
+          // When menu is open, use border-2 (no ring to avoid double border)
+          menuIsOpen && "border-primary border-2",
+          // Disabled state
+          controlDisabled && "cursor-not-allowed opacity-50",
+          // Dark mode
+          "dark:bg-input/30 dark:hover:bg-input/50",
+          // Remove default react-select background
+          "bg-body-bg",
+          className,
+        ),
+      placeholder: () => "text-muted-foreground",
+      input: () => "text-foreground",
+      singleValue: () => "text-foreground",
+      valueContainer: () => "gap-1 p-0",
+      indicatorSeparator: () => "hidden",
+      indicatorsContainer: () => "gap-1",
+      dropdownIndicator: () => "text-muted-foreground p-0",
+      clearIndicator: () => "text-muted-foreground p-0 cursor-pointer",
+      menu: () =>
+        cn(
+          "bg-popover text-popover-foreground relative z-50 min-w-[8rem] overflow-hidden rounded-md border shadow-md",
+          // Animation classes matching SelectContent
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        ),
+      menuList: () => "p-1 max-h-[300px]",
+      option: ({ isFocused, isSelected, isDisabled: optionDisabled, data }) =>
+        cn(
+          // Base styles matching SelectItem
+          "relative flex w-full cursor-default gap-2 rounded-sm py-1.5 px-2 !text-sm outline-hidden select-none",
+          data.description ? "items-start" : "items-center",
+          // Hover/focus state
+          isFocused && "bg-accent text-accent-foreground",
+          // Selected state
+          isSelected && "bg-accent text-accent-foreground",
+          // Disabled state
+          optionDisabled && "pointer-events-none opacity-50",
+        ),
+      group: () => "",
+      groupHeading: () =>
+        "text-muted-foreground px-2 py-1.5 text-xs font-semibold uppercase",
+      noOptionsMessage: () => "text-muted-foreground py-6 text-center text-sm",
+      loadingMessage: () => "text-muted-foreground py-6 text-center text-sm",
+      multiValue: () => "",
+      multiValueLabel: () => "text-sm",
+      multiValueRemove: () =>
+        "hover:bg-destructive/20 hover:text-destructive rounded-sm p-0.5 transition-colors cursor-pointer",
+    }),
+    [size, className],
+  );
 
   // Remove all default styles to use only classNames
-  const styles: StylesConfig<Option, IsMulti, Group> = {
-    control: () => ({
-      boxShadow: "none",
-    }),
-    option: (base) => ({
-      ...base,
-      backgroundColor: undefined,
-      color: undefined,
-      "&:active": {
-        backgroundColor: undefined,
-      },
-    }),
-    menu: (base) => ({
-      ...base,
-      backgroundColor: undefined,
-    }),
-    menuList: (base) => ({
-      ...base,
-      padding: undefined,
-    }),
-    multiValue: (base) => ({
-      ...base,
-      backgroundColor: undefined,
-    }),
-    multiValueLabel: (base) => ({
-      ...base,
-      color: undefined,
-      padding: undefined,
-    }),
-    multiValueRemove: (base) => ({
-      ...base,
-      color: undefined,
-      "&:hover": {
+  const styles = React.useMemo<StylesConfig<Option, IsMulti, Group>>(
+    () => ({
+      control: () => ({
+        boxShadow: "none",
+      }),
+      option: (base) => ({
+        ...base,
         backgroundColor: undefined,
         color: undefined,
-      },
+        "&:active": {
+          backgroundColor: undefined,
+        },
+      }),
+      menu: (base) => ({
+        ...base,
+        backgroundColor: undefined,
+      }),
+      menuList: (base) => ({
+        ...base,
+        padding: undefined,
+      }),
+      multiValue: (base) => ({
+        ...base,
+        backgroundColor: undefined,
+      }),
+      multiValueLabel: (base) => ({
+        ...base,
+        color: undefined,
+        padding: undefined,
+      }),
+      multiValueRemove: (base) => ({
+        ...base,
+        color: undefined,
+        "&:hover": {
+          backgroundColor: undefined,
+          color: undefined,
+        },
+      }),
+      input: (base) => ({
+        ...base,
+        color: undefined,
+      }),
+      placeholder: (base) => ({
+        ...base,
+        color: undefined,
+      }),
+      singleValue: (base) => ({
+        ...base,
+        color: undefined,
+      }),
+      indicatorSeparator: () => ({
+        display: "none",
+      }),
+      dropdownIndicator: (base) => ({
+        ...base,
+        color: undefined,
+        padding: 0,
+      }),
+      clearIndicator: (base) => ({
+        ...base,
+        color: undefined,
+        padding: 0,
+      }),
     }),
-    input: (base) => ({
-      ...base,
-      color: undefined,
+    [],
+  );
+
+  const mergedComponents = React.useMemo(
+    () => ({
+      DropdownIndicator,
+      ClearIndicator,
+      MultiValueContainer,
+      MultiValueRemove,
+      Option: CustomOption,
+      // Virtualized menu for large flat lists; a custom `MenuList` overrides this.
+      MenuList: VirtualizedMenuList as typeof components.MenuList,
+      ...userComponents,
     }),
-    placeholder: (base) => ({
-      ...base,
-      color: undefined,
-    }),
-    singleValue: (base) => ({
-      ...base,
-      color: undefined,
-    }),
-    indicatorSeparator: () => ({
-      display: "none",
-    }),
-    dropdownIndicator: (base) => ({
-      ...base,
-      color: undefined,
-      padding: 0,
-    }),
-    clearIndicator: (base) => ({
-      ...base,
-      color: undefined,
-      padding: 0,
-    }),
-  };
+    [userComponents],
+  );
 
   return (
     <ReactSelect<Option, IsMulti, Group>
@@ -276,14 +486,7 @@ function SelectReact<
       instanceId={selectInstanceId}
       classNames={classNames}
       styles={styles}
-      components={{
-        DropdownIndicator,
-        ClearIndicator,
-        MultiValueContainer,
-        MultiValueRemove,
-        Option: CustomOption as typeof components.Option,
-        ...userComponents,
-      }}
+      components={mergedComponents}
       isDisabled={isDisabled}
       isOptionDisabled={(option) => !!(option as SelectReactOption).disabled}
       {...props}

--- a/src/components/ui/select-react.tsx
+++ b/src/components/ui/select-react.tsx
@@ -15,9 +15,7 @@ import ReactSelect, {
   type MultiValueRemoveProps,
   type MultiValueGenericProps,
   type OptionProps,
-  type MenuListProps,
 } from "react-select";
-import { List, type ListImperativeAPI } from "react-window";
 
 import { cn } from "@/lib/utils";
 
@@ -134,193 +132,6 @@ const CustomOption = React.memo(function CustomOption<
     </components.Option>
   );
 }) as typeof components.Option;
-
-const MENU_VIRTUALIZE_THRESHOLD = 50;
-const MENU_ROW_SINGLE = 40;
-const MENU_ROW_WITH_DESCRIPTION = 64;
-
-type VirtualMenuRowProps = { menuRows: readonly React.ReactNode[] };
-
-function isGroupedOptions<Option>(
-  options: readonly Option[] | unknown,
-): boolean {
-  if (!Array.isArray(options) || options.length === 0) return false;
-  const first = options[0] as { options?: unknown };
-  return (
-    first != null &&
-    typeof first === "object" &&
-    "options" in first &&
-    Array.isArray(first.options)
-  );
-}
-
-function menuRowHeight(child: React.ReactNode): number {
-  if (React.isValidElement(child)) {
-    const data = (child.props as { data?: SelectReactOption }).data;
-    if (data?.description) return MENU_ROW_WITH_DESCRIPTION;
-  }
-  return MENU_ROW_SINGLE;
-}
-
-function totalMenuContentHeight(
-  menuRows: readonly React.ReactNode[],
-  rowHeightFn: (index: number, props: VirtualMenuRowProps) => number,
-  rowProps: VirtualMenuRowProps,
-): number {
-  let sum = 0;
-  for (let i = 0; i < menuRows.length; i++) {
-    sum += rowHeightFn(i, rowProps);
-  }
-  return sum;
-}
-
-type VirtualizedMenuListInnerProps<
-  Option extends SelectReactOption,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>,
-> = MenuListProps<Option, IsMulti, Group> & {
-  items: readonly React.ReactNode[];
-};
-
-/** Holds all list virtualization hooks; only mounted when the menu uses the virtualized path. */
-function VirtualizedMenuListInner<
-  Option extends SelectReactOption,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>,
->({ items, ...props }: VirtualizedMenuListInnerProps<Option, IsMulti, Group>) {
-  const {
-    maxHeight,
-    innerRef,
-    innerProps,
-    focusedOption,
-    isMulti,
-    cx,
-    getClassNames,
-    className,
-  } = props;
-
-  const rowProps = React.useMemo<VirtualMenuRowProps>(
-    () => ({ menuRows: items }),
-    [items],
-  );
-
-  const rowHeightFn = React.useCallback(
-    (index: number, p: VirtualMenuRowProps) => menuRowHeight(p.menuRows[index]),
-    [],
-  );
-
-  const contentHeight = React.useMemo(
-    () => totalMenuContentHeight(items, rowHeightFn, rowProps),
-    [items, rowHeightFn, rowProps],
-  );
-
-  const listViewportHeight = Math.min(maxHeight, contentHeight);
-
-  const listClassName = cx(
-    { "menu-list": true, "menu-list--is-multi": isMulti },
-    getClassNames("menuList", props),
-    className,
-  );
-
-  const listRef = React.useRef<ListImperativeAPI | null>(null);
-  const innerRefLatest = React.useRef(innerRef);
-  innerRefLatest.current = innerRef;
-
-  const assignMenuListElementRef = React.useCallback(
-    (element: HTMLDivElement | null) => {
-      const ref = innerRefLatest.current;
-      if (typeof ref === "function") {
-        ref(element);
-      } else if (ref && typeof ref === "object" && "current" in ref) {
-        (ref as React.MutableRefObject<HTMLDivElement | null>).current =
-          element;
-      }
-    },
-    [],
-  );
-
-  React.useLayoutEffect(() => {
-    assignMenuListElementRef(listRef.current?.element ?? null);
-    return () => assignMenuListElementRef(null);
-  }, [assignMenuListElementRef]);
-
-  React.useLayoutEffect(() => {
-    if (!focusedOption || items.length === 0) return;
-    const index = items.findIndex(
-      (row) =>
-        React.isValidElement(row) &&
-        (row.props as { data?: Option }).data === focusedOption,
-    );
-    if (index < 0) return;
-    queueMicrotask(() => {
-      listRef.current?.scrollToRow({ index, align: "auto" });
-    });
-  }, [focusedOption, items]);
-
-  const rowComponent = React.useCallback(
-    ({
-      index,
-      style,
-      menuRows,
-    }: {
-      ariaAttributes: {
-        "aria-posinset": number;
-        "aria-setsize": number;
-        role: "listitem";
-      };
-      index: number;
-      style: React.CSSProperties;
-    } & VirtualMenuRowProps) => (
-      <div role="presentation" style={style}>
-        {menuRows[index]}
-      </div>
-    ),
-    [],
-  );
-
-  return (
-    <List<VirtualMenuRowProps>
-      {...innerProps}
-      className={cn(listClassName, innerProps.className)}
-      listRef={listRef}
-      onResize={() =>
-        assignMenuListElementRef(listRef.current?.element ?? null)
-      }
-      onRowsRendered={() =>
-        assignMenuListElementRef(listRef.current?.element ?? null)
-      }
-      overscanCount={5}
-      rowComponent={rowComponent}
-      rowCount={items.length}
-      rowHeight={rowHeightFn}
-      rowProps={rowProps}
-      style={{ height: listViewportHeight, width: "100%" }}
-    />
-  );
-}
-
-function VirtualizedMenuList<
-  Option extends SelectReactOption,
-  IsMulti extends boolean,
-  Group extends GroupBase<Option>,
->(props: MenuListProps<Option, IsMulti, Group>) {
-  const { children, selectProps } = props;
-  const items = React.useMemo(
-    () => React.Children.toArray(children),
-    [children],
-  );
-  const options = selectProps.options;
-
-  if (
-    isGroupedOptions(options) ||
-    items.length <= MENU_VIRTUALIZE_THRESHOLD ||
-    items.length === 0
-  ) {
-    return <components.MenuList {...props} />;
-  }
-
-  return <VirtualizedMenuListInner {...props} items={items} />;
-}
 
 function SelectReact<
   Option extends SelectReactOption = SelectReactOption,
@@ -473,8 +284,6 @@ function SelectReact<
       MultiValueContainer,
       MultiValueRemove,
       Option: CustomOption,
-      // Virtualized menu for large flat lists; a custom `MenuList` overrides this.
-      MenuList: VirtualizedMenuList as typeof components.MenuList,
       ...userComponents,
     }),
     [userComponents],


### PR DESCRIPTION
## Description
### Accessibility
- Addresses **critical accessibility** issues (focus, semantics, and patterns that blocked or confused AT users). Landed via [#691](https://github.com/Sitecore/blok/pull/691).
### Usage
- **Usage** content and presentation updated so instructions and references match current behavior and are easier to scan. Landed via [#688](https://github.com/Sitecore/blok/pull/688), with follow-up tweaks to the usage section where needed.
### Installation tab
- **Installation tab UX** refined: clearer flow, layout, and interaction for installing or configuring components. Landed via [#690](https://github.com/Sitecore/blok/pull/690), with additional installation-tab polish as needed.
### Filters
- **Filters** expose better **labels and ARIA** so screen readers and keyboard users get meaningful names and relationships for filter UI.
## Related
- [#688](https://github.com/Sitecore/blok/pull/688) — Update Usage  
- [#690](https://github.com/Sitecore/blok/pull/690) — Installation Tab UX  
- [#691](https://github.com/Sitecore/blok/pull/691) — Critical Accessibility Issues  
## Testing instructions
1. **Usage** — Open the usage area; verify copy, structure, and links.
2. **Installation** — Use the installation tab end-to-end; confirm steps and controls feel clear and consistent.
3. **Filters** — With keyboard and a screen reader, confirm filters are announced with correct names and state.
4. **Regression** — Re-check primary flows touched by the accessibility fixes in #691.
## Reviewers
@sc-ishankalakshan
## Checklist
- [X] `npm run lint` (Biome) passes—no new lint issues in changed files  
- [X] Biome formatting applied where needed (`npm run lint:fix` and/or `npm run format`)  
- [X] Code follows the project style guidelines  
- [X] Self-reviewed the code changes  
- [X] Comments added for non-obvious parts of the code  
- [X] No new warnings or errors introduced  