### PR TITLE
Align filter trigger accessible names with visible labels (WCAG 2.5.3)

### DIFF
--- a/src/app/content/ui/filter/filter-multi-select.tsx
+++ b/src/app/content/ui/filter/filter-multi-select.tsx
@@ -48,7 +48,6 @@ export default function FilterMultiSelectDemo() {
         placeholder="Multi-select filter"
         groups={BLOCKCN_FILTER_GROUPS}
         ariaLabels={{
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         }}
@@ -61,7 +60,6 @@ export default function FilterMultiSelectDemo() {
         groups={BLOCKCN_FILTER_GROUPS}
         displayMode="badge"
         ariaLabels={{
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         }}

--- a/src/app/content/ui/filter/filter-single-select.tsx
+++ b/src/app/content/ui/filter/filter-single-select.tsx
@@ -47,7 +47,6 @@ export default function FilterSingleSelectDemo() {
         placeholder="Single select filter"
         groups={BLOCKCN_FILTER_GROUPS}
         ariaLabels={{
-          popoverTrigger: "Select an option",
           listbox: "List of options",
           clearSelection: "Clear selection",
         }}

--- a/src/app/content/ui/filter/filter-with-avatar.tsx
+++ b/src/app/content/ui/filter/filter-with-avatar.tsx
@@ -65,7 +65,6 @@ export default function FilterWithAvatarDemo() {
         options={[]}
         placeholder="Single select filter"
         ariaLabels={{
-          popoverTrigger: "Select an option",
           listbox: "List of options",
           clearSelection: "Clear selection",
         }}
@@ -87,7 +86,6 @@ export default function FilterWithAvatarDemo() {
         noResultsText="No results found"
         renderOption={renderOptionWithAvatar}
         ariaLabels={{
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         }}

--- a/src/app/content/ui/filter/filter-with-search.tsx
+++ b/src/app/content/ui/filter/filter-with-search.tsx
@@ -52,7 +52,6 @@ export default function FilterWithSearchDemo() {
         searchPlaceholder="Search"
         noResultsText="No results found"
         ariaLabels={{
-          popoverTrigger: "Select an option",
           searchInput: "Search",
           listbox: "List of options",
           clearSelection: "Clear selection",
@@ -69,7 +68,6 @@ export default function FilterWithSearchDemo() {
         searchPlaceholder="Search"
         noResultsText="No results found"
         ariaLabels={{
-          popoverTrigger: "Select options",
           searchInput: "Search",
           listbox: "List of options",
           clearSelection: "Clear all selections",

--- a/src/app/content/ui/filter/filter.tsx
+++ b/src/app/content/ui/filter/filter.tsx
@@ -61,7 +61,6 @@ export default function FilterDemo() {
         placeholder: "Single select filter",
         groups: BLOCKCN_FILTER_GROUPS,
         ariaLabels: {
-          popoverTrigger: "Select an option",
           listbox: "List of options",
           clearSelection: "Clear selection",
         },
@@ -75,7 +74,6 @@ export default function FilterDemo() {
         placeholder: "Multi-select filter",
         groups: BLOCKCN_FILTER_GROUPS,
         ariaLabels: {
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         },


### PR DESCRIPTION
## Summary

This PR fixes a WCAG SC 2.5.3 (Label in Name) violation on filter demo pages. Filter popover triggers displayed visible labels such as **Multi-select filter**, but their accessible name was overridden to **Select options** via `ariaLabels.popoverTrigger`. That mismatch fails accessibility scans and breaks voice control, because speech input relies on the visible label matching the accessible name.

## Description

Removed `popoverTrigger` from `ariaLabels` in all filter content demos. The shared `FilterSingleSelect` and `FilterMultiSelect` components already fall back to the `placeholder` when no custom trigger label is provided:

```tsx
aria-label={ariaLabels?.popoverTrigger ?? placeholder}