### PR TITLE
[feat]: Virtualized Select React component and filter accessibility fixes

### DIFF
--- a/registries/registry.json
+++ b/registries/registry.json
@@ -1412,6 +1412,27 @@
       ]
     },
     {
+      "name": "virtualized-select",
+      "type": "registry:ui",
+      "title": "Virtualized Select (React Select)",
+      "description": "An optimized select component built with React Select that supports virtualized rendering of large lists.",
+      "dependencies": ["react-select", "react-window"],
+      "registryDependencies": [
+        "https://blok.sitecore.com/r/theme.json",
+        "https://blok.sitecore.com/r/select-react.json"
+      ],
+      "files": [
+        {
+          "path": "src/components/ui/virtualized-select.tsx",
+          "type": "registry:ui"
+        },
+        {
+          "path": "src/lib/icon.tsx",
+          "type": "registry:lib"
+        }
+      ]
+    },
+    {
       "name": "separator",
       "type": "registry:ui",
       "title": "Separator",

--- a/src/app/content/ui/filter/filter-multi-select.tsx
+++ b/src/app/content/ui/filter/filter-multi-select.tsx
@@ -48,7 +48,6 @@ export default function FilterMultiSelectDemo() {
         placeholder="Multi-select filter"
         groups={BLOCKCN_FILTER_GROUPS}
         ariaLabels={{
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         }}
@@ -61,7 +60,6 @@ export default function FilterMultiSelectDemo() {
         groups={BLOCKCN_FILTER_GROUPS}
         displayMode="badge"
         ariaLabels={{
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         }}

--- a/src/app/content/ui/filter/filter-single-select.tsx
+++ b/src/app/content/ui/filter/filter-single-select.tsx
@@ -47,7 +47,6 @@ export default function FilterSingleSelectDemo() {
         placeholder="Single select filter"
         groups={BLOCKCN_FILTER_GROUPS}
         ariaLabels={{
-          popoverTrigger: "Select an option",
           listbox: "List of options",
           clearSelection: "Clear selection",
         }}

--- a/src/app/content/ui/filter/filter-with-avatar.tsx
+++ b/src/app/content/ui/filter/filter-with-avatar.tsx
@@ -65,7 +65,6 @@ export default function FilterWithAvatarDemo() {
         options={[]}
         placeholder="Single select filter"
         ariaLabels={{
-          popoverTrigger: "Select an option",
           listbox: "List of options",
           clearSelection: "Clear selection",
         }}
@@ -87,7 +86,6 @@ export default function FilterWithAvatarDemo() {
         noResultsText="No results found"
         renderOption={renderOptionWithAvatar}
         ariaLabels={{
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         }}

--- a/src/app/content/ui/filter/filter-with-search.tsx
+++ b/src/app/content/ui/filter/filter-with-search.tsx
@@ -52,7 +52,6 @@ export default function FilterWithSearchDemo() {
         searchPlaceholder="Search"
         noResultsText="No results found"
         ariaLabels={{
-          popoverTrigger: "Select an option",
           searchInput: "Search",
           listbox: "List of options",
           clearSelection: "Clear selection",
@@ -69,7 +68,6 @@ export default function FilterWithSearchDemo() {
         searchPlaceholder="Search"
         noResultsText="No results found"
         ariaLabels={{
-          popoverTrigger: "Select options",
           searchInput: "Search",
           listbox: "List of options",
           clearSelection: "Clear all selections",

--- a/src/app/content/ui/filter/filter.tsx
+++ b/src/app/content/ui/filter/filter.tsx
@@ -61,7 +61,6 @@ export default function FilterDemo() {
         placeholder: "Single select filter",
         groups: BLOCKCN_FILTER_GROUPS,
         ariaLabels: {
-          popoverTrigger: "Select an option",
           listbox: "List of options",
           clearSelection: "Clear selection",
         },
@@ -75,7 +74,6 @@ export default function FilterDemo() {
         placeholder: "Multi-select filter",
         groups: BLOCKCN_FILTER_GROUPS,
         ariaLabels: {
-          popoverTrigger: "Select options",
           listbox: "List of options",
           clearSelection: "Clear all selections",
         },

--- a/src/app/content/ui/select-react/virtualized-select.tsx
+++ b/src/app/content/ui/select-react/virtualized-select.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  type SelectReactOption,
+  VirtualizedSelect,
+} from "@/components/ui/virtualized-select";
+
+function versionOptionIcon(major: number, minor: number) {
+  return (
+    <Avatar className="size-8 shrink-0">
+      <AvatarFallback className="text-xs font-medium">
+        {`${major}.${minor}`}
+      </AvatarFallback>
+    </Avatar>
+  );
+}
+
+function createVersionOptions(count: number): SelectReactOption[] {
+  const options: SelectReactOption[] = [];
+  let x = 1;
+  let y = 0;
+  let z = 0;
+
+  for (let i = 0; i < count; i++) {
+    const version = `v${x}.${y}.${z}`;
+    const release = `${x}.${y}.${z}`;
+
+    options.push({
+      value: version,
+      label: version,
+      description: `release ${release}`,
+      icon: versionOptionIcon(x, y),
+    });
+
+    if (i === count - 1) break;
+
+    z += 1;
+    if (z > 9) {
+      z = 0;
+      y += 1;
+      if (y > 9) {
+        y = 0;
+        x += 1;
+      }
+    }
+  }
+
+  return options;
+}
+
+const options = createVersionOptions(2000);
+
+export default function VirtualizedSelectDemo() {
+  return (
+    <div className="p-2 w-[320px]">
+      <VirtualizedSelect
+        options={options}
+        placeholder="Select a version"
+        aria-label="Select a version"
+      />
+    </div>
+  );
+}

--- a/src/app/demo/[name]/page.tsx
+++ b/src/app/demo/[name]/page.tsx
@@ -131,7 +131,7 @@ export default async function DemoPage({
 
 const componentDemo = (component: ReactNode) => {
   return (
-    <div className="relative rounded-lg">
+    <div className="relative overflow-visible rounded-lg">
       <Renderer>{component}</Renderer>
     </div>
   );

--- a/src/app/demo/[name]/ui/select-react.tsx
+++ b/src/app/demo/[name]/ui/select-react.tsx
@@ -1,5 +1,9 @@
+import InstallationCodeBlock from "@/components/docsite/installation-code-block";
 import { Alert } from "@/components/ui/alert";
 import Link from "next/link";
+
+const baseUrl = process.env.NEXT_PUBLIC_REGISTRY_URL ?? "";
+const registryUrl = `https://${baseUrl}/r/virtualized-select.json`;
 
 export const selectReact = {
   name: "select-react",
@@ -22,6 +26,25 @@ export const selectReact = {
     ),
     defaultComponent: "select-react",
   },
+  installation: {
+    post: (
+      <div className="flex w-full flex-col gap-4 pt-3">
+        <p className="text-muted-foreground text-base">
+          Install{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono">
+            virtualized-select
+          </code>{" "}
+          for an optimized React Select when you need to render a very large
+          list of options. The menu virtualizes rows so performance stays smooth
+          with thousands of items.
+        </p>
+        <InstallationCodeBlock
+          registryUrl={registryUrl}
+          componentName="virtualized-select"
+        />
+      </div>
+    ),
+  },
   usage: {
     usage: [
       `import { SelectReact, type SelectReactOption } from "@/components/ui/select-react";`,
@@ -41,5 +64,8 @@ export const selectReact = {
   placeholder="Select an option"
 />`,
     ],
+  },
+  components: {
+    "Virtualized Select": { component: "virtualized-select" },
   },
 };

--- a/src/components/demo-tab.tsx
+++ b/src/components/demo-tab.tsx
@@ -101,7 +101,7 @@ export default function DemoTab({
     <Tabs
       id={id}
       defaultValue={defaultTab}
-      className="gap-0"
+      className="gap-0 overflow-visible"
       onValueChange={handleTabChange}
     >
       <TabsList className="w-full rounded-none justify-start">
@@ -116,10 +116,10 @@ export default function DemoTab({
       </TabsList>
       <TabsContent
         value="preview"
-        className="min-h-[200px] p-8 bg-subtle-bg flex items-center justify-center rounded-b-md"
+        className="min-h-[200px] overflow-visible p-8 bg-subtle-bg flex items-center justify-center rounded-b-md"
       >
         <div
-          className="min-h-[200px] w-full flex items-center justify-center"
+          className="min-h-[200px] w-full overflow-visible flex items-center justify-center"
           onClick={() => handlePreviewInteraction("click")}
           onFocusCapture={() => handlePreviewInteraction("focus")}
           role="presentation"

--- a/src/components/docsite/component-card.tsx
+++ b/src/components/docsite/component-card.tsx
@@ -13,7 +13,7 @@ export function ComponentCard({ component }: ComponentCardProps) {
   return (
     <section>
       <div id="starting-kit">
-        <div className="w-full overflow-hidden">
+        <div className="w-full overflow-visible">
           <DemoWrapper name={component.name} />
           {/* <iframe
             id="iframe"

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -48,6 +48,38 @@ interface SearchResult {
   title?: string;
 }
 
+const SELECT_REACT_PRIMITIVE_HREF = "/primitives/select-react";
+
+function registryItemMatchesQuery(
+  query: string,
+  fields: {
+    name?: string;
+    title?: string;
+    description?: string;
+    categories?: string[];
+  },
+): boolean {
+  const name = fields.name || "";
+  const title = fields.title || name;
+  const description = fields.description || "";
+  const categories = fields.categories || [];
+
+  return (
+    name.toLowerCase().includes(query) ||
+    title.toLowerCase().includes(query) ||
+    description.toLowerCase().includes(query) ||
+    categories.some((cat) => cat.toLowerCase().includes(query))
+  );
+}
+
+function dedupeSearchResultsByHref(results: SearchResult[]): SearchResult[] {
+  const byHref = new Map<string, SearchResult>();
+  for (const result of results) {
+    byHref.set(result.href, result);
+  }
+  return [...byHref.values()];
+}
+
 /**
  * Radix DropdownMenu assigns unstable `id`s via React `useId()`. Rendering it
  * only after mount avoids SSR/client drift (and reduces noise when extensions
@@ -230,9 +262,12 @@ export default function TopBar() {
     const results: SearchResult[] = [];
 
     try {
-      // Search through UI components
+      // Search through UI components (virtualized-select is documented on select-react)
       registry.items
-        .filter((item) => item.type === "registry:ui")
+        .filter(
+          (item) =>
+            item.type === "registry:ui" && item.name !== "virtualized-select",
+        )
         .forEach((item) => {
           const name = item.name || "";
           const title = (item as any).title || name;
@@ -240,10 +275,12 @@ export default function TopBar() {
           const categories = (item as any).categories || [];
 
           if (
-            name.toLowerCase().includes(query) ||
-            title.toLowerCase().includes(query) ||
-            description.toLowerCase().includes(query) ||
-            categories.some((cat: string) => cat.toLowerCase().includes(query))
+            registryItemMatchesQuery(query, {
+              name,
+              title,
+              description,
+              categories,
+            })
           ) {
             results.push({
               name: item.name,
@@ -255,6 +292,35 @@ export default function TopBar() {
             });
           }
         });
+
+      const virtualizedSelect = registry.items.find(
+        (item) => item.name === "virtualized-select",
+      );
+      if (virtualizedSelect) {
+        const title =
+          (virtualizedSelect as { title?: string }).title ||
+          virtualizedSelect.name;
+        const categories =
+          (virtualizedSelect as { categories?: string[] }).categories || [];
+
+        if (
+          registryItemMatchesQuery(query, {
+            name: virtualizedSelect.name,
+            title,
+            description: virtualizedSelect.description,
+            categories,
+          })
+        ) {
+          results.push({
+            name: "select-react",
+            type: "ui",
+            href: SELECT_REACT_PRIMITIVE_HREF,
+            description: virtualizedSelect.description,
+            categories,
+            title,
+          });
+        }
+      }
 
       // Search through blocks
       registry.items
@@ -301,7 +367,7 @@ export default function TopBar() {
         }
       });
 
-      setSearchResults(results.slice(0, 8));
+      setSearchResults(dedupeSearchResultsByHref(results).slice(0, 8));
       setShowSearchResults(results.length > 0);
       setSelectedIndex(-1);
     } catch (error) {

--- a/src/components/ui/virtualized-select.tsx
+++ b/src/components/ui/virtualized-select.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import {
+  SelectReact,
+  type SelectReactOption,
+  type SelectReactProps,
+} from "@/components/ui/select-react";
+import * as React from "react";
+import { type GroupBase, type MenuListProps, components } from "react-select";
+import { List, type ListImperativeAPI } from "react-window";
+
+import { cn } from "@/lib/utils";
+
+export type { SelectReactOption, SelectReactProps };
+
+const MENU_VIRTUALIZE_THRESHOLD = 50;
+const MENU_ROW_SINGLE = 40;
+const MENU_ROW_WITH_DESCRIPTION = 64;
+
+type VirtualMenuRowProps = { menuRows: readonly React.ReactNode[] };
+
+function isGroupedOptions<Option>(
+  options: readonly Option[] | unknown,
+): boolean {
+  if (!Array.isArray(options) || options.length === 0) return false;
+  const first = options[0] as { options?: unknown };
+  return (
+    first != null &&
+    typeof first === "object" &&
+    "options" in first &&
+    Array.isArray(first.options)
+  );
+}
+
+function menuRowHeight(child: React.ReactNode): number {
+  if (React.isValidElement(child)) {
+    const data = (child.props as { data?: SelectReactOption }).data;
+    if (data?.description) return MENU_ROW_WITH_DESCRIPTION;
+  }
+  return MENU_ROW_SINGLE;
+}
+
+function totalMenuContentHeight(
+  menuRows: readonly React.ReactNode[],
+  rowHeightFn: (index: number, props: VirtualMenuRowProps) => number,
+  rowProps: VirtualMenuRowProps,
+): number {
+  let sum = 0;
+  for (let i = 0; i < menuRows.length; i++) {
+    sum += rowHeightFn(i, rowProps);
+  }
+  return sum;
+}
+
+type VirtualizedMenuListInnerProps<
+  Option extends SelectReactOption,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+> = MenuListProps<Option, IsMulti, Group> & {
+  items: readonly React.ReactNode[];
+};
+
+/** Holds all list virtualization hooks; only mounted when the menu uses the virtualized path. */
+function VirtualizedMenuListInner<
+  Option extends SelectReactOption,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+>({ items, ...props }: VirtualizedMenuListInnerProps<Option, IsMulti, Group>) {
+  const {
+    maxHeight,
+    innerRef,
+    innerProps,
+    focusedOption,
+    isMulti,
+    cx,
+    getClassNames,
+    className,
+  } = props;
+
+  const rowProps = React.useMemo<VirtualMenuRowProps>(
+    () => ({ menuRows: items }),
+    [items],
+  );
+
+  const rowHeightFn = React.useCallback(
+    (index: number, p: VirtualMenuRowProps) => menuRowHeight(p.menuRows[index]),
+    [],
+  );
+
+  const contentHeight = React.useMemo(
+    () => totalMenuContentHeight(items, rowHeightFn, rowProps),
+    [items, rowHeightFn, rowProps],
+  );
+
+  const listViewportHeight = Math.min(maxHeight, contentHeight);
+
+  const listClassName = cx(
+    { "menu-list": true, "menu-list--is-multi": isMulti },
+    getClassNames("menuList", props),
+    className,
+  );
+
+  const listRef = React.useRef<ListImperativeAPI | null>(null);
+  const innerRefLatest = React.useRef(innerRef);
+  innerRefLatest.current = innerRef;
+
+  const assignMenuListElementRef = React.useCallback(
+    (element: HTMLDivElement | null) => {
+      const ref = innerRefLatest.current;
+      if (typeof ref === "function") {
+        ref(element);
+      } else if (ref && typeof ref === "object" && "current" in ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current =
+          element;
+      }
+    },
+    [],
+  );
+
+  React.useLayoutEffect(() => {
+    assignMenuListElementRef(listRef.current?.element ?? null);
+    return () => assignMenuListElementRef(null);
+  }, [assignMenuListElementRef]);
+
+  React.useLayoutEffect(() => {
+    if (!focusedOption || items.length === 0) return;
+    const index = items.findIndex(
+      (row) =>
+        React.isValidElement(row) &&
+        (row.props as { data?: Option }).data === focusedOption,
+    );
+    if (index < 0) return;
+    queueMicrotask(() => {
+      listRef.current?.scrollToRow({ index, align: "auto" });
+    });
+  }, [focusedOption, items]);
+
+  const rowComponent = React.useCallback(
+    ({
+      index,
+      style,
+      menuRows,
+    }: {
+      ariaAttributes: {
+        "aria-posinset": number;
+        "aria-setsize": number;
+        role: "listitem";
+      };
+      index: number;
+      style: React.CSSProperties;
+    } & VirtualMenuRowProps) => (
+      <div role="presentation" style={style}>
+        {menuRows[index]}
+      </div>
+    ),
+    [],
+  );
+
+  return (
+    <List<VirtualMenuRowProps>
+      {...innerProps}
+      className={cn(listClassName, innerProps.className)}
+      listRef={listRef}
+      onResize={() =>
+        assignMenuListElementRef(listRef.current?.element ?? null)
+      }
+      onRowsRendered={() =>
+        assignMenuListElementRef(listRef.current?.element ?? null)
+      }
+      overscanCount={5}
+      rowComponent={rowComponent}
+      rowCount={items.length}
+      rowHeight={rowHeightFn}
+      rowProps={rowProps}
+      style={{ height: listViewportHeight, width: "100%" }}
+    />
+  );
+}
+
+function VirtualizedMenuList<
+  Option extends SelectReactOption,
+  IsMulti extends boolean,
+  Group extends GroupBase<Option>,
+>(props: MenuListProps<Option, IsMulti, Group>) {
+  const { children, selectProps } = props;
+  const items = React.useMemo(
+    () => React.Children.toArray(children),
+    [children],
+  );
+  const options = selectProps.options;
+
+  if (
+    isGroupedOptions(options) ||
+    items.length <= MENU_VIRTUALIZE_THRESHOLD ||
+    items.length === 0
+  ) {
+    return <components.MenuList {...props} />;
+  }
+
+  return <VirtualizedMenuListInner {...props} items={items} />;
+}
+
+function VirtualizedSelect<
+  Option extends SelectReactOption = SelectReactOption,
+  IsMulti extends boolean = false,
+  Group extends GroupBase<Option> = GroupBase<Option>,
+>({
+  components: userComponents,
+  ...props
+}: SelectReactProps<Option, IsMulti, Group>) {
+  return (
+    <SelectReact<Option, IsMulti, Group>
+      {...props}
+      components={{
+        MenuList: VirtualizedMenuList as typeof components.MenuList,
+        ...userComponents,
+      }}
+    />
+  );
+}
+
+export { VirtualizedSelect };

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -159,6 +159,7 @@ import SelectLargeListDemo from "@/app/content/ui/select/select-large-list";
 import SelectWithIconDemo from "@/app/content/ui/select/select-icon";
 import DisabledSelectDemo from "@/app/content/ui/select/select-disabled";
 import SelectReactDemo from "@/app/content/ui/select-react/select-react";
+import VirtualizedSelectDemo from "@/app/content/ui/select-react/virtualized-select";
 import SeparatorDemo from "@/app/content/ui/separator/separator";
 import SheetDemo from "@/app/content/ui/sheet/sheet";
 import SheetDirectionsDemo from "@/app/content/ui/sheet/sheet-directions";
@@ -1080,6 +1081,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "select-react",
     path: "src/app/content/ui/select-react/select-react.tsx",
     component: SelectReactDemo,
+  },
+  "virtualized-select": {
+    name: "virtualized-select",
+    path: "src/app/content/ui/select-react/virtualized-select.tsx",
+    component: VirtualizedSelectDemo,
   },
   separator: {
     name: "separator",

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -42,6 +42,10 @@ export function getBlocks() {
 // Get Components
 export function getComponents() {
   return getRegistryItems()
-    .filter((component) => component.type === "registry:ui")
+    .filter(
+      (component) =>
+        component.type === "registry:ui" &&
+        component.name !== "virtualized-select",
+    )
     .sort((a, b) => a.title.localeCompare(b.title));
 }

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -750,6 +750,11 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
       { id: "preview", title: "Preview" },
       { id: "installation", title: "Installation" },
       { id: "usage", title: "Usage" },
+      {
+        id: "examples",
+        title: "Examples",
+        children: [{ id: "virtualized-select", title: "Virtualized Select" }],
+      },
     ],
   },
   separator: {


### PR DESCRIPTION
## Summary

1. **Virtualized Select** — a new registry component for large option lists, built on `SelectReact` with `react-window` virtualization.
2. **Filter accessibility** — filter trigger accessible names now match visible labels (WCAG 2.5.3 Label in Name).

---

## Description

### Virtualized Select (`SelectReact`)

- Adds `VirtualizedSelect` in `src/components/ui/virtualized-select.tsx`, wrapping `SelectReact` with a custom `MenuList` that virtualizes rows via `react-window`.
- Registers `virtualized-select` in the component registry (`registries/registry.json`) with dependencies on `react-select` and `react-window`.
- Docs and demos:
  - Documented under the **Select React** primitive page as an **Examples → Virtualized Select** tab
  - Installation block added to the select-react demo page
- Search/navigation:
  - Topbar search maps `virtualized-select` queries to `/primitives/select-react`
  - `virtualized-select` is excluded from the standalone components list (lives under select-react)
  - Duplicate search results are deduped by `href`

### Accessibility fixes (Filter)

- Resolves **WCAG 2.5.3 (Label in Name)** for filter triggers.
- Filter demos no longer pass generic `popoverTrigger` labels (e.g. `"Select an option"`) that differed from the visible placeholder text.
- Triggers now inherit accessible names from the **placeholder** via existing fallback logic in `Filter` (`ariaLabels?.popoverTrigger ?? placeholder`).

### Docsite / demo layout

- Sets `overflow-visible` on demo tab preview containers, demo page wrapper, and component card wrapper so select menus render outside clipped preview areas.