### PR TITLE
[Feat]: Add error state to editable

### DIFF
--- a/src/app/content/ui/editable/editable-error.tsx
+++ b/src/app/content/ui/editable/editable-error.tsx
@@ -1,0 +1,24 @@
+import {
+  Editable,
+  EditableError,
+  EditableInput,
+  EditablePreview,
+} from "@/components/ui/editable";
+
+export default function EditableErrorDemo() {
+  const error = "This field is required";
+
+  return (
+    <div className="w-96">
+      <Editable
+        defaultValue="Click to edit this text"
+        placeholder="Enter some text..."
+        hasError={Boolean(error)}
+      >
+        <EditablePreview className="w-80" />
+        <EditableInput className="w-80" aria-invalid={Boolean(error)} />
+        <EditableError>{error}</EditableError>
+      </Editable>
+    </div>
+  );
+}

--- a/src/app/content/ui/editable/editable-error.tsx
+++ b/src/app/content/ui/editable/editable-error.tsx
@@ -1,23 +1,33 @@
+"use client";
+
 import {
   Editable,
   EditableError,
   EditableInput,
   EditablePreview,
 } from "@/components/ui/editable";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+
+const ERROR_MESSAGE = "This field is required";
 
 export default function EditableErrorDemo() {
-  const error = "This field is required";
+  const [showError, setShowError] = useState(false);
 
   return (
     <div className="w-96">
       <Editable
-        defaultValue="Click to edit this text"
-        placeholder="Enter some text..."
-        hasError={Boolean(error)}
+        defaultValue=""
+        placeholder="Click to edit this text"
+        hasError={showError}
+        onEdit={() => setShowError(true)}
       >
         <EditablePreview className="w-80" />
-        <EditableInput className="w-80" aria-invalid={Boolean(error)} />
-        <EditableError>{error}</EditableError>
+        <EditableInput
+          className={cn("w-80", showError && "border-destructive")}
+          aria-invalid={showError}
+        />
+        {showError ? <EditableError>{ERROR_MESSAGE}</EditableError> : null}
       </Editable>
     </div>
   );

--- a/src/app/demo/[name]/ui/editable.tsx
+++ b/src/app/demo/[name]/ui/editable.tsx
@@ -23,5 +23,6 @@ export const editable = {
   },
   components: {
     Textarea: { component: "editable-textarea" },
+    "Editable with Error": { component: "editable-error" },
   },
 };

--- a/src/components/ui/editable.tsx
+++ b/src/components/ui/editable.tsx
@@ -370,7 +370,7 @@ const editablePreviewVariants = cva(
   {
     variants: {
       isEmpty: {
-        true: "text-muted-foreground italic",
+        true: "text-foreground",
         false: "text-foreground",
       },
     },

--- a/src/components/ui/editable.tsx
+++ b/src/components/ui/editable.tsx
@@ -57,6 +57,8 @@ interface UseEditableProps {
   selectAllOnFocus?: boolean;
   /** Activation mode: 'click' or 'dblclick' */
   activationMode?: ActivationMode;
+  /** Error message to display */
+  hasError?: boolean;
   /** Callback when value is submitted */
   onSubmit?: (value: string) => void;
   /** Callback when value changes */
@@ -85,6 +87,7 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
     startWithEditView = false,
     selectAllOnFocus = true,
     activationMode = "click",
+    hasError = false,
     onSubmit,
     onChange,
     onValueChange,
@@ -92,7 +95,9 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
     onEdit,
   } = props;
 
-  const [isEditing, setIsEditing] = React.useState(startWithEditView);
+  const [isEditing, setIsEditing] = React.useState(
+    startWithEditView || hasError,
+  );
   const [internalValue, setInternalValue] = React.useState(defaultValue);
   const [previousValue, setPreviousValue] = React.useState(defaultValue);
   const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement | null>(
@@ -114,14 +119,14 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
     if (!isControlled) {
       setInternalValue(previousValue);
     }
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onCancel?.(previousValue);
-  }, [isControlled, previousValue, onCancel]);
+  }, [isControlled, previousValue, onCancel, hasError]);
 
   const submitEdit = React.useCallback(() => {
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onSubmit?.(value);
-  }, [value, onSubmit]);
+  }, [value, onSubmit, hasError]);
 
   const handleChange = React.useCallback(
     (newValue: string) => {
@@ -169,7 +174,7 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
 
 // Editable Root Component
 
-const editableVariants = cva("inline-flex flex-col gap-1", {
+const editableVariants = cva("inline-flex flex-col gap-1 relative", {
   variants: {
     size: {
       sm: "text-sm",
@@ -203,6 +208,8 @@ interface EditableProps
   selectAllOnFocus?: boolean;
   /** Activation mode: 'click' or 'dblclick' */
   activationMode?: ActivationMode;
+  /** Error message to display */
+  hasError?: boolean;
   /** Callback when value is submitted */
   onSubmit?: (value: string) => void;
   /** Callback when value changes */
@@ -227,6 +234,7 @@ function Editable({
   startWithEditView = false,
   selectAllOnFocus = true,
   activationMode = "click",
+  hasError = false,
   onSubmit,
   onChange,
   onValueChange,
@@ -235,7 +243,9 @@ function Editable({
   children,
   ...props
 }: EditableProps) {
-  const [isEditing, setIsEditing] = React.useState(startWithEditView);
+  const [isEditing, setIsEditing] = React.useState(
+    startWithEditView || hasError,
+  );
   const [internalValue, setInternalValue] = React.useState(defaultValue);
   const [previousValue, setPreviousValue] = React.useState(defaultValue);
   const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement | null>(
@@ -257,14 +267,14 @@ function Editable({
     if (!isControlled) {
       setInternalValue(previousValue);
     }
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onCancel?.(previousValue);
-  }, [isControlled, previousValue, onCancel]);
+  }, [isControlled, previousValue, onCancel, hasError]);
 
   const submitEdit = React.useCallback(() => {
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onSubmit?.(value);
-  }, [value, onSubmit]);
+  }, [value, onSubmit, hasError]);
 
   const handleChange = React.useCallback(
     (newValue: string) => {
@@ -355,7 +365,7 @@ const editablePreviewVariants = cva(
   [
     "cursor-text rounded-md px-2 py-1 transition-colors",
     "hover:bg-neutral-bg",
-    "min-h-[2rem] flex items-center whitespace-pre-line break-words",
+    "min-h-8 flex items-center whitespace-pre-line break-words",
   ].join(" "),
   {
     variants: {
@@ -474,7 +484,7 @@ function EditableInput({ className, ...props }: EditableInputProps) {
         }
       }}
       className={cn(
-        "w-full border-2 bg-transparent dark:bg-transparent focus-visible:ring-0 focus-visible:border-primary transition-colors",
+        "w-full border-2 bg-transparent h-8 dark:bg-transparent focus-visible:ring-0 focus-visible:border-primary transition-colors",
         className,
       )}
       {...props}
@@ -649,6 +659,47 @@ function EditableSubmitTrigger({
   );
 }
 
+interface EditableErrorProps extends React.HTMLAttributes<HTMLDivElement> {
+  errors?: { message?: string }[];
+}
+
+function EditableError({
+  errors,
+  children,
+  className,
+  ...props
+}: EditableErrorProps) {
+  const errorMessages = errors?.filter(Boolean) || [];
+
+  if (errorMessages.length === 0 && !children) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      data-slot="editable-error"
+      className={cn(
+        "text-sm text-destructive absolute w-max px-2 bottom-[calc(-100%+var(--spacing)*2)] cursor-default z-10",
+        className,
+      )}
+      {...props}
+    >
+      {children ||
+        (errorMessages.length === 1 ? (
+          <span>{errorMessages[0]?.message}</span>
+        ) : (
+          <ul className="list-disc list-inside space-y-1">
+            {errorMessages.map((error, index) => (
+              <li key={index}>{error?.message}</li>
+            ))}
+          </ul>
+        ))}
+    </div>
+  );
+}
+
 export {
   Editable,
   EditableRootProvider,
@@ -659,6 +710,7 @@ export {
   EditableEditTrigger,
   EditableCancelTrigger,
   EditableSubmitTrigger,
+  EditableError,
   editableVariants,
   editablePreviewVariants,
   useEditable,

--- a/src/components/ui/editable.tsx
+++ b/src/components/ui/editable.tsx
@@ -681,7 +681,7 @@ function EditableError({
       aria-live="polite"
       data-slot="editable-error"
       className={cn(
-        "text-sm text-destructive absolute w-max px-2 bottom-[calc(-100%+var(--spacing)*2)] cursor-default z-10",
+        "text-sm text-destructive absolute w-max bg-white rounded-sm shadow-lg py-1 px-2 bottom-[calc(-100%+var(--spacing)*0.5)] cursor-default z-10",
         className,
       )}
       {...props}

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -87,6 +87,7 @@ import DropdownMenuIconColorDemo from "@/app/content/ui/dropdown/dropdown-menu-i
 import DropdownMenuWithDescriptionDemo from "@/app/content/ui/dropdown/dropdown-menu-with-description";
 import EditableDemo from "@/app/content/ui/editable/editable";
 import EditableTextareaDemo from "@/app/content/ui/editable/editable-textarea";
+import EditableErrorDemo from "@/app/content/ui/editable/editable-error";
 import EmptyStatesNoSearchResultsDemo from "@/app/content/ui/empty-states/empty-states-no-search-results";
 import EmptyStatesNothingCreatedDemo from "@/app/content/ui/empty-states/empty-states-nothing-created";
 import EmptyStatesErrorDemo from "@/app/content/ui/empty-states/empty-states-error";
@@ -676,6 +677,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "editable-textarea",
     path: "src/app/content/ui/editable/editable-textarea.tsx",
     component: EditableTextareaDemo,
+  },
+  "editable-error": {
+    name: "editable-error",
+    path: "src/app/content/ui/editable/editable-error.tsx",
+    component: EditableErrorDemo,
   },
   "empty-states-no-results": {
     name: "empty-states-no-results",

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -351,7 +351,10 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
       {
         id: "examples",
         title: "Examples",
-        children: [{ id: "editable-textarea", title: "Textarea" }],
+        children: [
+          { id: "editable-textarea", title: "Textarea" },
+          { id: "editable-error", title: "Editable with Error" },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary
Adds error state to the `editable` primitive. This is crucial for form validation.

## Description
Added `EditableError` sub component to the `Editable` primitive and added error state handling. Added the new demo `Editable with Error` to display the use case of Editable Error. Docsite registry and Right sidebar registry were updated with the new demo,