### PR TITLE
[feat]: Editable error state and Sidebar RHS updates

### DIFF
--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed.tsx
@@ -7,7 +7,6 @@ import { useState } from "react";
 import {
   DEMO_SIDEBAR_DOCKABLE,
   EXAMPLE_HEIGHT,
-  ExpandableDescription,
   InfoSection,
   UsageSection,
   navigationItems,
@@ -15,7 +14,15 @@ import {
 
 function SidebarContent({ activeTab }: { activeTab: string }) {
   const tabContent: Record<string, React.ReactNode> = {
-    "/overview": <ExpandableDescription />,
+    "/overview": (
+      <div className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold">Description</h3>
+        <p className="text-sm text-foreground">
+          A fixed sidebar stays open with no collapse control or left-edge
+          resize interaction.
+        </p>
+      </div>
+    ),
     "/usage": <UsageSection />,
     "/comments": (
       <p className="text-sm text-muted-foreground">Comments tab content.</p>
@@ -26,7 +33,7 @@ function SidebarContent({ activeTab }: { activeTab: string }) {
   return <>{tabContent[activeTab] || tabContent["/overview"]}</>;
 }
 
-export default function SidebarRHSDemo() {
+export default function SidebarRHSFixedDemo() {
   const [activeTab, setActiveTab] = useState("/overview");
 
   const stackedNavigationHeader = (
@@ -54,8 +61,8 @@ export default function SidebarRHSDemo() {
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
-                Collapsible sidebar with stacked navigation tabs. Pass any
-                content as children of SidebarRHS.
+                Fixed sidebar — always visible with no collapse or resize
+                controls.
               </p>
             </div>
           </main>
@@ -67,7 +74,7 @@ export default function SidebarRHSDemo() {
             minWidth="250px"
             maxWidth="600px"
             height="100%"
-            collapsible={true}
+            collapsible={false}
             dockable={DEMO_SIDEBAR_DOCKABLE}
           >
             <SidebarContent activeTab={activeTab} />

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-tab-content.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-tab-content.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  SearchInput,
+  SearchInputField,
+  SearchInputLeftElement,
+} from "@/components/ui/search-input";
+import type { StackNavigationElement } from "@/components/ui/stack-navigation";
+import { Icon } from "@/lib/icon";
+import {
+  mdiCommentOutline,
+  mdiContentCopy,
+  mdiInformationOutline,
+  mdiLayers,
+  mdiMagnify,
+  mdiViewDashboard,
+} from "@mdi/js";
+import { useState } from "react";
+
+export const EXAMPLE_HEIGHT = "h-[720px]";
+
+/** Demos hide pop-out by default. Set to true to show dock/undock controls again. */
+export const DEMO_SIDEBAR_DOCKABLE = false;
+
+export const navigationItems: StackNavigationElement[] = [
+  {
+    name: "Overview",
+    path: "/overview",
+    icon: <Icon path={mdiViewDashboard} />,
+  },
+  {
+    name: "Usage",
+    path: "/usage",
+    icon: <Icon path={mdiLayers} />,
+  },
+  {
+    name: "Comments",
+    path: "/comments",
+    icon: <Icon path={mdiCommentOutline} />,
+  },
+  {
+    name: "Info",
+    path: "/info",
+    icon: <Icon path={mdiInformationOutline} />,
+  },
+];
+
+export function ExpandableDescription() {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const fullText = `Sitecore is a leading digital experience platform that empowers organizations to create, manage, and deliver personalized content across all channels. With its powerful content management system, marketers and developers can collaborate seamlessly to build engaging customer experiences.`;
+
+  const truncatedText = fullText.substring(0, 200);
+  const shouldTruncate = fullText.length > 200;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold">Description</h3>
+      <div className="relative">
+        <p className="text-sm text-foreground">
+          {isExpanded ? fullText : truncatedText}
+        </p>
+        {!isExpanded && shouldTruncate && (
+          <div className="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-body-bg to-transparent pointer-events-none" />
+        )}
+      </div>
+      {shouldTruncate && (
+        <Button
+          type="button"
+          variant="link"
+          colorScheme="neutral"
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="text-sm text-center font-semibold"
+        >
+          {isExpanded ? "Read less" : "Read more"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function UsageSection() {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const briefItems = [
+    {
+      name: "Campaign Brief Q1",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Product Launch Brief",
+      status: "Published",
+      statusColor: "success" as const,
+    },
+    {
+      name: "Homepage Refresh Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Holiday Campaign Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Partner Portal Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Brand Guidelines Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Email Nurture Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "App Onboarding Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Regional Launch Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Content Hub Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Analytics Rollout Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+    {
+      name: "Support Portal Brief",
+      status: "Draft",
+      statusColor: "neutral" as const,
+    },
+  ];
+
+  const filteredItems = briefItems.filter((item) =>
+    item.name.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-sm text-muted-foreground">
+        Briefs that are using this brief type
+      </p>
+
+      <SearchInput className="w-full">
+        <SearchInputLeftElement>
+          <Icon path={mdiMagnify} />
+        </SearchInputLeftElement>
+        <SearchInputField
+          placeholder="Search"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </SearchInput>
+
+      <div className="flex flex-col">
+        {filteredItems.map((item) => (
+          <div
+            key={item.name}
+            className="flex items-center gap-3 rounded-lg p-2"
+          >
+            <p className="flex-1 min-w-0 truncate text-sm font-semibold text-foreground">
+              {item.name}
+            </p>
+            <Badge
+              size="sm"
+              colorScheme={item.statusColor}
+              className="shrink-0"
+            >
+              {item.status}
+            </Badge>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function InfoSection() {
+  const handleCopy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-neutral-fg">Label</p>
+        <div className="flex items-center gap-1">
+          <span className="flex-1 min-w-0 truncate text-sm text-foreground">
+            The label
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => handleCopy("The label")}
+            className="shrink-0 text-muted-foreground shadow-none hover:text-foreground"
+            aria-label="Copy label"
+          >
+            <Icon path={mdiContentCopy} className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-neutral-fg">Name</p>
+        <div className="flex items-center gap-1">
+          <span className="flex-1 min-w-0 truncate text-sm text-foreground">
+            Value
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => handleCopy("Value")}
+            className="shrink-0 text-muted-foreground shadow-none hover:text-foreground"
+            aria-label="Copy name"
+          >
+            <Icon path={mdiContentCopy} className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-neutral-fg">Created by</p>
+        <span className="text-sm text-foreground">Value</span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-neutral-fg">Created</p>
+        <span className="text-sm text-foreground">Person, Date</span>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-neutral-fg">Updated</p>
+        <span className="text-sm text-foreground">Person, Date</span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/content/ui/editable/editable-error.tsx
+++ b/src/app/content/ui/editable/editable-error.tsx
@@ -1,0 +1,24 @@
+import {
+  Editable,
+  EditableError,
+  EditableInput,
+  EditablePreview,
+} from "@/components/ui/editable";
+
+export default function EditableErrorDemo() {
+  const error = "This field is required";
+
+  return (
+    <div className="w-96">
+      <Editable
+        defaultValue="Click to edit this text"
+        placeholder="Enter some text..."
+        hasError={Boolean(error)}
+      >
+        <EditablePreview className="w-80" />
+        <EditableInput className="w-80" aria-invalid={Boolean(error)} />
+        <EditableError>{error}</EditableError>
+      </Editable>
+    </div>
+  );
+}

--- a/src/app/content/ui/editable/editable-error.tsx
+++ b/src/app/content/ui/editable/editable-error.tsx
@@ -1,23 +1,33 @@
+"use client";
+
 import {
   Editable,
   EditableError,
   EditableInput,
   EditablePreview,
 } from "@/components/ui/editable";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+
+const ERROR_MESSAGE = "This field is required";
 
 export default function EditableErrorDemo() {
-  const error = "This field is required";
+  const [showError, setShowError] = useState(false);
 
   return (
     <div className="w-96">
       <Editable
-        defaultValue="Click to edit this text"
-        placeholder="Enter some text..."
-        hasError={Boolean(error)}
+        defaultValue=""
+        placeholder="Click to edit this text"
+        hasError={showError}
+        onEdit={() => setShowError(true)}
       >
         <EditablePreview className="w-80" />
-        <EditableInput className="w-80" aria-invalid={Boolean(error)} />
-        <EditableError>{error}</EditableError>
+        <EditableInput
+          className={cn("w-80", showError && "border-destructive")}
+          aria-invalid={showError}
+        />
+        {showError ? <EditableError>{ERROR_MESSAGE}</EditableError> : null}
       </Editable>
     </div>
   );

--- a/src/app/demo/[name]/bloks/sidebar-rhs.tsx
+++ b/src/app/demo/[name]/bloks/sidebar-rhs.tsx
@@ -2,27 +2,52 @@ export const sidebarRhs = {
   name: "sidebar-rhs",
   preview: {
     defaultComponent: "sidebar-rhs",
+    contentClassName:
+      "p-0 h-[720px] min-h-[720px] max-h-[720px] w-full items-stretch justify-start",
+    wrapperClassName: "rounded-none h-[720px] w-full",
+  },
+  components: {
+    Fixed: {
+      component: "sidebar-rhs-fixed",
+      contentClassName:
+        "p-0 h-[720px] min-h-[720px] max-h-[720px] w-full items-stretch justify-start",
+      wrapperClassName: "rounded-none h-[720px] w-full",
+    },
   },
   usage: {
     usage: [
       `import { SidebarRHSProvider, SidebarRHS } from "@/components/bloks/sidebar-rhs";
+import { StackNavigation } from "@/components/ui/stack-navigation";
 
 <SidebarRHSProvider>
   <div className="relative w-full h-screen flex">
-    <main className="flex-1 overflow-auto">
-      {/* Your main content */}
-    </main>
-    <SidebarRHS title="My Sidebar" width="360px" height="100vh">
-      <div>Sidebar content</div>
+    <main className="flex-1 overflow-auto">{/* page content */}</main>
+    <SidebarRHS
+      header={
+        <StackNavigation
+          items={navItems}
+          orientation="horizontal"
+          colorScheme="neutral"
+          pathname={activeTab}
+          onItemClick={(item, e) => {
+            e.preventDefault();
+            setActiveTab(item.path);
+            return false;
+          }}
+          className="shadow-none h-auto bg-transparent p-0 w-full"
+        />
+      }
+      width="360px"
+      height="100vh"
+      collapsible
+      dockable={false}
+    >
+      {/* Any content for the active tab */}
+      {yourTabContent}
     </SidebarRHS>
+    {/* dockable={true} — optional: show undock control for floating draggable sidebar */}
   </div>
 </SidebarRHSProvider>`,
     ],
-  },
-  components: {
-    "Heading with Tabs": { component: "sidebar-rhs-heading-with-tabs" },
-    Brief: { component: "sidebar-rhs-brief" },
-    "Brief Type": { component: "sidebar-rhs-brief-type" },
-    Content: { component: "sidebar-rhs-content" },
   },
 };

--- a/src/app/demo/[name]/index.tsx
+++ b/src/app/demo/[name]/index.tsx
@@ -80,6 +80,10 @@ interface Demo {
     pre?: ReactNode | ReactElement;
     defaultComponent: string;
     post?: ReactNode | ReactElement;
+    /** Override DemoTab preview panel classes (e.g. remove padding for full-bleed layouts). */
+    contentClassName?: string;
+    /** Override the wrapper around the preview component. */
+    wrapperClassName?: string;
   };
   installation?: {
     pre?: ReactNode | ReactElement;
@@ -95,6 +99,8 @@ interface Demo {
       pre?: ReactNode | ReactElement;
       component: ReactNode | ReactElement;
       post?: ReactNode | ReactElement;
+      contentClassName?: string;
+      wrapperClassName?: string;
     };
   };
 }

--- a/src/app/demo/[name]/page.tsx
+++ b/src/app/demo/[name]/page.tsx
@@ -5,6 +5,7 @@ import DemoTab from "@/components/demo-tab";
 import InstallationCodeBlock from "@/components/docsite/installation-code-block";
 import type { docsiteRegistry } from "@/lib/docsite/docsite-registry";
 import { loadFromRegistry } from "@/lib/docsite/load-from-registry";
+import { cn } from "@/lib/utils";
 import { notFound } from "next/navigation";
 import React, { type ComponentType } from "react";
 import type { ReactNode } from "react";
@@ -60,11 +61,13 @@ export default async function DemoPage({
                 code={entry.code}
                 component={componentDemo(
                   React.createElement(entry.Component as ComponentType<any>),
+                  component.wrapperClassName,
                 )}
                 componentName={name}
                 section="examples"
                 exampleId={component.component as string}
                 exampleTitle={title}
+                previewContentClassName={component.contentClassName}
               />
               {component.post}
             </div>
@@ -83,9 +86,11 @@ export default async function DemoPage({
         code={defaultEntry.code}
         component={componentDemo(
           React.createElement(defaultEntry.Component as ComponentType<any>),
+          preview.wrapperClassName,
         )}
         componentName={name}
         section="main"
+        previewContentClassName={preview.contentClassName}
       />
       {preview.post}
 
@@ -129,9 +134,9 @@ export default async function DemoPage({
   );
 }
 
-const componentDemo = (component: ReactNode) => {
+const componentDemo = (component: ReactNode, wrapperClassName?: string) => {
   return (
-    <div className="relative rounded-lg">
+    <div className={cn("relative rounded-lg", wrapperClassName)}>
       <Renderer>{component}</Renderer>
     </div>
   );

--- a/src/app/demo/[name]/ui/editable.tsx
+++ b/src/app/demo/[name]/ui/editable.tsx
@@ -23,5 +23,6 @@ export const editable = {
   },
   components: {
     Textarea: { component: "editable-textarea" },
+    "Editable with Error": { component: "editable-error" },
   },
 };

--- a/src/components/bloks/sidebar-rhs.tsx
+++ b/src/components/bloks/sidebar-rhs.tsx
@@ -171,7 +171,7 @@ export interface SidebarRHSProps {
   title?: string;
   /** Custom header content (overrides title if provided) */
   header?: ReactNode;
-  /** Content to display in the sidebar */
+  /** Content to display in the sidebar body (below the header) */
   children?: ReactNode;
   /** Main content area (shown on the left) */
   mainContent?: ReactNode;
@@ -185,12 +185,88 @@ export interface SidebarRHSProps {
   maxWidth?: string;
   /** Callback when width changes */
   onWidthChange?: (width: string) => void;
-  /** Additional className */
+  /** Additional className on the sidebar root */
   className?: string;
-  /** Enable collapsible functionality (default: true) */
+  /** ClassName for the header region */
+  headerClassName?: string;
+  /** ClassName for the scrollable content region below the header */
+  contentClassName?: string;
+  /** Enable collapsible functionality */
   collapsible?: boolean;
-  /** Enable dock/undock functionality (default: true) */
+  /**
+   * Shows dock/undock controls (pop-out to a floating, draggable panel).
+   * When false, pop-out UI is hidden only — docked vs undocked logic stays in the component.
+   * Set to true to re-enable without further changes.
+   */
   dockable?: boolean;
+  /** Show left-edge resize handle and hover stroke (defaults to match collapsible) */
+  resizable?: boolean;
+}
+
+function SidebarResizeHandle({
+  onMouseDown,
+}: {
+  onMouseDown: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <div
+      className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize z-20 group/resize"
+      onMouseDown={onMouseDown}
+      role="separator"
+      aria-label="Resize sidebar"
+      aria-orientation="vertical"
+    >
+      <div className="absolute inset-y-0 left-0 w-px bg-transparent group-hover/resize:bg-primary transition-colors" />
+    </div>
+  );
+}
+
+function SidebarRHSInner({
+  header,
+  title,
+  children,
+  dockable,
+  headerClassName,
+  contentClassName,
+  isStackedNavHeader,
+}: {
+  header?: ReactNode;
+  title?: string;
+  children?: ReactNode;
+  dockable?: boolean;
+  headerClassName?: string;
+  contentClassName?: string;
+  isStackedNavHeader: boolean;
+}) {
+  return (
+    <>
+      <div
+        className={cn(
+          "shrink-0 flex items-center justify-between w-full gap-2",
+          isStackedNavHeader
+            ? "sticky top-0 z-10 bg-body-bg pt-4 pb-2 px-6"
+            : "h-12 px-4",
+          headerClassName,
+        )}
+      >
+        <div className={cn(isStackedNavHeader && "flex-1 min-w-0 w-full")}>
+          {header ||
+            (title && <h2 className="text-lg font-semibold">{title}</h2>)}
+        </div>
+        <DockButton show={dockable} />
+      </div>
+
+      <div
+        className={cn(
+          "flex-1 min-h-0 overflow-auto",
+          isStackedNavHeader ? "px-6 py-4" : "p-4",
+          contentClassName,
+        )}
+      >
+        {children}
+      </div>
+    </>
+  );
 }
 
 // Helper function to parse width string to pixels
@@ -258,10 +334,15 @@ export function SidebarRHS({
   maxWidth = "800px",
   onWidthChange,
   className,
+  headerClassName,
+  contentClassName,
   collapsible = false,
   dockable = false,
+  resizable: resizableProp,
   ...props
 }: SidebarRHSProps & ComponentProps<"div">) {
+  const isStackedNavHeader = !!header;
+  const resizable = resizableProp ?? collapsible;
   const { isCollapsed, isDocked } = useSidebarRHS();
   const [currentWidth, setCurrentWidth] = useState(width);
   const [isResizing, setIsResizing] = useState(false);
@@ -429,30 +510,19 @@ export function SidebarRHS({
           {/* Sidebar */}
           <div
             className={cn(
-              "relative bg-body-bg border-l border-border shrink-0 overflow-x-visible",
-              isCollapsed && "border-l-0",
+              "relative bg-body-bg shrink-0 overflow-x-visible",
               !isResizing && "transition-all ease-in-out",
-              !isResizing && transitionDuration === "500" && "duration-500", // Slower when collapsing
-              !isResizing && transitionDuration === "200" && "duration-200", // Faster when expanding
+              !isResizing && transitionDuration === "500" && "duration-500",
+              !isResizing && transitionDuration === "200" && "duration-200",
             )}
             style={{
               width: isCollapsed ? "0" : currentWidth,
             }}
           >
-            {/* Resize handle */}
-            {!shouldHideContent && (
-              <div
-                className="absolute -left-1 top-0 bottom-0 w-2 cursor-ew-resize z-20 hover:bg-primary/20 transition-colors group"
-                onMouseDown={handleResizeStart}
-                role="separator"
-                aria-label="Resize sidebar"
-                aria-orientation="vertical"
-              >
-                <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-border group-hover:bg-primary" />
-              </div>
+            {resizable && !shouldHideContent && (
+              <SidebarResizeHandle onMouseDown={handleResizeStart} />
             )}
 
-            {/* Collapse/Expand button - on the resize border */}
             {collapsible && (
               <SidebarRHSTrigger
                 className="absolute top-1/2 -translate-y-1/2 z-30"
@@ -470,15 +540,16 @@ export function SidebarRHS({
                   "opacity-100 transition-opacity duration-200",
               )}
             >
-              {/* Header */}
-              <div className="flex h-12 items-center justify-between px-4 shrink-0">
-                {header ||
-                  (title && <h2 className="text-lg font-semibold">{title}</h2>)}
-                <DockButton show={dockable} />
-              </div>
-
-              {/* Content */}
-              <div className="flex-1 overflow-auto p-4">{children}</div>
+              <SidebarRHSInner
+                header={header}
+                title={title}
+                dockable={dockable}
+                headerClassName={headerClassName}
+                contentClassName={contentClassName}
+                isStackedNavHeader={isStackedNavHeader}
+              >
+                {children}
+              </SidebarRHSInner>
             </div>
           </div>
         </div>
@@ -491,11 +562,10 @@ export function SidebarRHS({
         ref={containerRef}
         {...props}
         className={cn(
-          "relative bg-body-bg border-l border-border shrink-0 overflow-x-visible",
-          isCollapsed && "border-l-0",
+          "relative bg-body-bg shrink-0 overflow-x-visible",
           !isResizing && "transition-all ease-in-out",
-          !isResizing && transitionDuration === "500" && "duration-500", // Slower when collapsing
-          !isResizing && transitionDuration === "200" && "duration-200", // Faster when expanding
+          !isResizing && transitionDuration === "500" && "duration-500",
+          !isResizing && transitionDuration === "200" && "duration-200",
           className,
         )}
         style={{
@@ -503,20 +573,10 @@ export function SidebarRHS({
           height: height,
         }}
       >
-        {/* Resize handle */}
-        {!shouldHideContent && (
-          <div
-            className="absolute -left-1 top-0 bottom-0 w-2 cursor-ew-resize z-20 hover:bg-primary/20 transition-colors group"
-            onMouseDown={handleResizeStart}
-            role="separator"
-            aria-label="Resize sidebar"
-            aria-orientation="vertical"
-          >
-            <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-0.5 bg-border group-hover:bg-primary" />
-          </div>
+        {resizable && !shouldHideContent && (
+          <SidebarResizeHandle onMouseDown={handleResizeStart} />
         )}
 
-        {/* Collapse/Expand button - on the resize border */}
         {collapsible && (
           <SidebarRHSTrigger
             className="absolute top-1/2 -translate-y-1/2 z-30"
@@ -533,15 +593,16 @@ export function SidebarRHS({
             !shouldHideContent && "opacity-100 transition-opacity duration-200",
           )}
         >
-          {/* Header */}
-          <div className="flex h-12 items-center justify-between px-4 shrink-0">
-            {header ||
-              (title && <h2 className="text-lg font-semibold">{title}</h2>)}
-            <DockButton show={dockable} />
-          </div>
-
-          {/* Content */}
-          <div className="flex-1 overflow-auto p-4">{children}</div>
+          <SidebarRHSInner
+            header={header}
+            title={title}
+            dockable={dockable}
+            headerClassName={headerClassName}
+            contentClassName={contentClassName}
+            isStackedNavHeader={isStackedNavHeader}
+          >
+            {children}
+          </SidebarRHSInner>
         </div>
       </div>
     );
@@ -602,10 +663,15 @@ export function SidebarRHS({
         )}
         style={style}
       >
-        <div className="flex h-full flex-col">
-          {/* Header - draggable area */}
+        <div className="flex h-full flex-col min-h-0">
           <div
-            className="flex h-12 items-center justify-between px-4 shrink-0 cursor-grab active:cursor-grabbing"
+            className={cn(
+              "shrink-0 flex items-center justify-between w-full cursor-grab active:cursor-grabbing",
+              isStackedNavHeader
+                ? "sticky top-0 z-10 bg-body-bg pt-4 pb-2 px-6"
+                : "h-12 px-4",
+              headerClassName,
+            )}
             {...listeners}
             {...attributes}
           >
@@ -616,8 +682,15 @@ export function SidebarRHS({
             <UndockButton show={dockable} />
           </div>
 
-          {/* Content */}
-          <div className="flex-1 overflow-auto p-4">{children}</div>
+          <div
+            className={cn(
+              "flex-1 min-h-0 overflow-auto",
+              isStackedNavHeader ? "px-6 py-4" : "p-4",
+              contentClassName,
+            )}
+          >
+            {children}
+          </div>
         </div>
       </div>
     );

--- a/src/components/demo-tab.tsx
+++ b/src/components/demo-tab.tsx
@@ -3,6 +3,7 @@
 import { CodeBlock, type CopyCodeContext } from "@/components/code-block";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TELEMETRY_EVENTS, track } from "@/lib/telemetry";
+import { cn } from "@/lib/utils";
 import { usePathname } from "next/navigation";
 import { type ReactNode, useCallback, useRef } from "react";
 
@@ -21,6 +22,8 @@ interface DemoTabProps {
   exampleId?: string;
   /** Telemetry: example title. */
   exampleTitle?: string;
+  /** Override preview panel classes (merged with defaults). */
+  previewContentClassName?: string;
 }
 
 export default function DemoTab({
@@ -32,6 +35,7 @@ export default function DemoTab({
   section = "main",
   exampleId,
   exampleTitle,
+  previewContentClassName,
 }: DemoTabProps) {
   const pathname = usePathname();
   const lastPreviewInteractionBySectionRef = useRef<Record<string, number>>({});
@@ -116,10 +120,17 @@ export default function DemoTab({
       </TabsList>
       <TabsContent
         value="preview"
-        className="min-h-[200px] p-8 bg-subtle-bg flex items-center justify-center rounded-b-md"
+        className={cn(
+          "min-h-[200px] p-8 bg-subtle-bg flex items-center justify-center rounded-b-md",
+          previewContentClassName,
+        )}
       >
         <div
-          className="min-h-[200px] w-full flex items-center justify-center"
+          className={cn(
+            "min-h-[200px] w-full flex items-center justify-center",
+            previewContentClassName?.includes("p-0") &&
+              "h-full min-h-0 items-stretch justify-start",
+          )}
           onClick={() => handlePreviewInteraction("click")}
           onFocusCapture={() => handlePreviewInteraction("focus")}
           role="presentation"

--- a/src/components/ui/editable.tsx
+++ b/src/components/ui/editable.tsx
@@ -370,7 +370,7 @@ const editablePreviewVariants = cva(
   {
     variants: {
       isEmpty: {
-        true: "text-muted-foreground italic",
+        true: "text-foreground",
         false: "text-foreground",
       },
     },

--- a/src/components/ui/editable.tsx
+++ b/src/components/ui/editable.tsx
@@ -57,6 +57,8 @@ interface UseEditableProps {
   selectAllOnFocus?: boolean;
   /** Activation mode: 'click' or 'dblclick' */
   activationMode?: ActivationMode;
+  /** Error message to display */
+  hasError?: boolean;
   /** Callback when value is submitted */
   onSubmit?: (value: string) => void;
   /** Callback when value changes */
@@ -85,6 +87,7 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
     startWithEditView = false,
     selectAllOnFocus = true,
     activationMode = "click",
+    hasError = false,
     onSubmit,
     onChange,
     onValueChange,
@@ -92,7 +95,9 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
     onEdit,
   } = props;
 
-  const [isEditing, setIsEditing] = React.useState(startWithEditView);
+  const [isEditing, setIsEditing] = React.useState(
+    startWithEditView || hasError,
+  );
   const [internalValue, setInternalValue] = React.useState(defaultValue);
   const [previousValue, setPreviousValue] = React.useState(defaultValue);
   const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement | null>(
@@ -114,14 +119,14 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
     if (!isControlled) {
       setInternalValue(previousValue);
     }
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onCancel?.(previousValue);
-  }, [isControlled, previousValue, onCancel]);
+  }, [isControlled, previousValue, onCancel, hasError]);
 
   const submitEdit = React.useCallback(() => {
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onSubmit?.(value);
-  }, [value, onSubmit]);
+  }, [value, onSubmit, hasError]);
 
   const handleChange = React.useCallback(
     (newValue: string) => {
@@ -169,7 +174,7 @@ function useEditable(props: UseEditableProps = {}): UseEditableReturn {
 
 // Editable Root Component
 
-const editableVariants = cva("inline-flex flex-col gap-1", {
+const editableVariants = cva("inline-flex flex-col gap-1 relative", {
   variants: {
     size: {
       sm: "text-sm",
@@ -203,6 +208,8 @@ interface EditableProps
   selectAllOnFocus?: boolean;
   /** Activation mode: 'click' or 'dblclick' */
   activationMode?: ActivationMode;
+  /** Error message to display */
+  hasError?: boolean;
   /** Callback when value is submitted */
   onSubmit?: (value: string) => void;
   /** Callback when value changes */
@@ -227,6 +234,7 @@ function Editable({
   startWithEditView = false,
   selectAllOnFocus = true,
   activationMode = "click",
+  hasError = false,
   onSubmit,
   onChange,
   onValueChange,
@@ -235,7 +243,9 @@ function Editable({
   children,
   ...props
 }: EditableProps) {
-  const [isEditing, setIsEditing] = React.useState(startWithEditView);
+  const [isEditing, setIsEditing] = React.useState(
+    startWithEditView || hasError,
+  );
   const [internalValue, setInternalValue] = React.useState(defaultValue);
   const [previousValue, setPreviousValue] = React.useState(defaultValue);
   const inputRef = React.useRef<HTMLInputElement | HTMLTextAreaElement | null>(
@@ -257,14 +267,14 @@ function Editable({
     if (!isControlled) {
       setInternalValue(previousValue);
     }
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onCancel?.(previousValue);
-  }, [isControlled, previousValue, onCancel]);
+  }, [isControlled, previousValue, onCancel, hasError]);
 
   const submitEdit = React.useCallback(() => {
-    setIsEditing(false);
+    setIsEditing(hasError || false);
     onSubmit?.(value);
-  }, [value, onSubmit]);
+  }, [value, onSubmit, hasError]);
 
   const handleChange = React.useCallback(
     (newValue: string) => {
@@ -355,7 +365,7 @@ const editablePreviewVariants = cva(
   [
     "cursor-text rounded-md px-2 py-1 transition-colors",
     "hover:bg-neutral-bg",
-    "min-h-[2rem] flex items-center whitespace-pre-line break-words",
+    "min-h-8 flex items-center whitespace-pre-line break-words",
   ].join(" "),
   {
     variants: {
@@ -474,7 +484,7 @@ function EditableInput({ className, ...props }: EditableInputProps) {
         }
       }}
       className={cn(
-        "w-full border-2 bg-transparent dark:bg-transparent focus-visible:ring-0 focus-visible:border-primary transition-colors",
+        "w-full border-2 bg-transparent h-8 dark:bg-transparent focus-visible:ring-0 focus-visible:border-primary transition-colors",
         className,
       )}
       {...props}
@@ -649,6 +659,47 @@ function EditableSubmitTrigger({
   );
 }
 
+interface EditableErrorProps extends React.HTMLAttributes<HTMLDivElement> {
+  errors?: { message?: string }[];
+}
+
+function EditableError({
+  errors,
+  children,
+  className,
+  ...props
+}: EditableErrorProps) {
+  const errorMessages = errors?.filter(Boolean) || [];
+
+  if (errorMessages.length === 0 && !children) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      data-slot="editable-error"
+      className={cn(
+        "text-sm text-destructive absolute w-max px-2 bottom-[calc(-100%+var(--spacing)*2)] cursor-default z-10",
+        className,
+      )}
+      {...props}
+    >
+      {children ||
+        (errorMessages.length === 1 ? (
+          <span>{errorMessages[0]?.message}</span>
+        ) : (
+          <ul className="list-disc list-inside space-y-1">
+            {errorMessages.map((error, index) => (
+              <li key={index}>{error?.message}</li>
+            ))}
+          </ul>
+        ))}
+    </div>
+  );
+}
+
 export {
   Editable,
   EditableRootProvider,
@@ -659,6 +710,7 @@ export {
   EditableEditTrigger,
   EditableCancelTrigger,
   EditableSubmitTrigger,
+  EditableError,
   editableVariants,
   editablePreviewVariants,
   useEditable,

--- a/src/components/ui/editable.tsx
+++ b/src/components/ui/editable.tsx
@@ -681,7 +681,7 @@ function EditableError({
       aria-live="polite"
       data-slot="editable-error"
       className={cn(
-        "text-sm text-destructive absolute w-max px-2 bottom-[calc(-100%+var(--spacing)*2)] cursor-default z-10",
+        "text-sm text-destructive absolute w-max bg-white rounded-sm shadow-lg py-1 px-2 bottom-[calc(-100%+var(--spacing)*0.5)] cursor-default z-10",
         className,
       )}
       {...props}

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -231,6 +231,7 @@ import PromptInputFloatingDemo from "@/app/content/bloks/prompt-input/prompt-inp
 import PromptInputQueuedDemo from "@/app/content/bloks/prompt-input/prompt-input-queued";
 import PromptInputQuestionsDemo from "@/app/content/bloks/prompt-input/prompt-input-questions";
 import SidebarRHSDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs";
+import SidebarRHSFixedDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed";
 import SidebarRHSHeadingWithTabsDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-heading-with-tabs";
 import SidebarRHSBriefDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-brief";
 import SidebarRHSBriefTypeDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-brief-type";
@@ -1387,6 +1388,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "sidebar-rhs",
     path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs.tsx",
     component: SidebarRHSDemo,
+  },
+  "sidebar-rhs-fixed": {
+    name: "sidebar-rhs-fixed",
+    path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed.tsx",
+    component: SidebarRHSFixedDemo,
   },
   "sidebar-rhs-heading-with-tabs": {
     name: "sidebar-rhs-heading-with-tabs",

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -87,6 +87,7 @@ import DropdownMenuIconColorDemo from "@/app/content/ui/dropdown/dropdown-menu-i
 import DropdownMenuWithDescriptionDemo from "@/app/content/ui/dropdown/dropdown-menu-with-description";
 import EditableDemo from "@/app/content/ui/editable/editable";
 import EditableTextareaDemo from "@/app/content/ui/editable/editable-textarea";
+import EditableErrorDemo from "@/app/content/ui/editable/editable-error";
 import EmptyStatesNoSearchResultsDemo from "@/app/content/ui/empty-states/empty-states-no-search-results";
 import EmptyStatesNothingCreatedDemo from "@/app/content/ui/empty-states/empty-states-nothing-created";
 import EmptyStatesErrorDemo from "@/app/content/ui/empty-states/empty-states-error";
@@ -676,6 +677,11 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "editable-textarea",
     path: "src/app/content/ui/editable/editable-textarea.tsx",
     component: EditableTextareaDemo,
+  },
+  "editable-error": {
+    name: "editable-error",
+    path: "src/app/content/ui/editable/editable-error.tsx",
+    component: EditableErrorDemo,
   },
   "empty-states-no-results": {
     name: "empty-states-no-results",

--- a/src/lib/docsite/docsite-registry.ts
+++ b/src/lib/docsite/docsite-registry.ts
@@ -232,10 +232,6 @@ import PromptInputQueuedDemo from "@/app/content/bloks/prompt-input/prompt-input
 import PromptInputQuestionsDemo from "@/app/content/bloks/prompt-input/prompt-input-questions";
 import SidebarRHSDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs";
 import SidebarRHSFixedDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed";
-import SidebarRHSHeadingWithTabsDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-heading-with-tabs";
-import SidebarRHSBriefDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-brief";
-import SidebarRHSBriefTypeDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-brief-type";
-import SidebarRHSContentDemo from "@/app/content/bloks/sidebar-rhs/sidebar-rhs-content";
 import SiteCardDemo from "@/app/content/bloks/site-card/site-card";
 import TopbarDemo from "@/app/content/bloks/topbar/topbar";
 
@@ -1393,26 +1389,6 @@ export const docsiteRegistry: Record<string, DocsiteRegistryEntry> = {
     name: "sidebar-rhs-fixed",
     path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed.tsx",
     component: SidebarRHSFixedDemo,
-  },
-  "sidebar-rhs-heading-with-tabs": {
-    name: "sidebar-rhs-heading-with-tabs",
-    path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs-heading-with-tabs.tsx",
-    component: SidebarRHSHeadingWithTabsDemo,
-  },
-  "sidebar-rhs-brief": {
-    name: "sidebar-rhs-brief",
-    path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs-brief.tsx",
-    component: SidebarRHSBriefDemo,
-  },
-  "sidebar-rhs-brief-type": {
-    name: "sidebar-rhs-brief-type",
-    path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs-brief-type.tsx",
-    component: SidebarRHSBriefTypeDemo,
-  },
-  "sidebar-rhs-content": {
-    name: "sidebar-rhs-content",
-    path: "src/app/content/bloks/sidebar-rhs/sidebar-rhs-content.tsx",
-    component: SidebarRHSContentDemo,
   },
   "site-card": {
     name: "site-card",

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -1088,24 +1088,7 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
       {
         id: "examples",
         title: "Examples",
-        children: [
-          {
-            id: "sidebar-rhs-heading-with-tabs",
-            title: "Heading with Tabs",
-          },
-          {
-            id: "sidebar-rhs-brief",
-            title: "Brief",
-          },
-          {
-            id: "sidebar-rhs-brief-type",
-            title: "Brief Type",
-          },
-          {
-            id: "sidebar-rhs-content",
-            title: "Content",
-          },
-        ],
+        children: [{ id: "sidebar-rhs-fixed", title: "Fixed" }],
       },
     ],
   },

--- a/src/lib/right-sidebar-metadata.ts
+++ b/src/lib/right-sidebar-metadata.ts
@@ -351,7 +351,10 @@ export const rightSidebarMetadata: Record<string, RightSidebarMetadata> = {
       {
         id: "examples",
         title: "Examples",
-        children: [{ id: "editable-textarea", title: "Textarea" }],
+        children: [
+          { id: "editable-textarea", title: "Textarea" },
+          { id: "editable-error", title: "Editable with Error" },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary

- **Editable** — validation-style error UI (`hasError`, `EditableError`) with a new docs example.
- **Sidebar RHS** — layout and API refinements aligned with design feedback, simplified docs/demos, and an opt-in `dockable` prop (off by default).

## Description

### Editable — error state ([#707](https://github.com/Sitecore/blok/pull/707))

- Added `hasError` on `Editable` / `useEditable` so failed validation can keep the field in edit mode after cancel/submit.
- Added compound component `EditableError` (`role="alert"`) for inline error messaging (supports `children` or an `errors` array).
- New docs example: **Editable with Error** (`editable-error`), registered in `docsite-registry` and right-sidebar TOC.

### Sidebar RHS — refresh ([#709](https://github.com/Sitecore/blok/pull/709))

- Refactored sidebar structure: dedicated header/body regions, `headerClassName` / `contentClassName`, and improved support for **stacked navigation** in the header.
- **`dockable`** (default `false`) — dock/undock controls are hidden unless explicitly enabled; undocked behavior remains in the component for future use.
- **`resizable`** — optional left-edge resize handle (defaults to match `collapsible`).
- Default demo: **collapsible** sidebar with horizontal `StackNavigation` tabs and shared tab content module (`sidebar-rhs-tab-content.tsx`).
- New **Fixed** example (`sidebar-rhs-fixed`) — non-collapsible, non-resizable sidebar.
- Removed legacy sidebar RHS examples (Heading with Tabs, Brief, Brief Type, Content) from the docs site and registry to reduce noise.
- Demo registry / usage snippets updated (`src/app/demo/[name]/bloks/sidebar-rhs.tsx`).

**Scope:** 13 files, ~+703 / −163 lines (component, content demos, docs registry, metadata).

**Tradeoffs:** `dockable={false}` by default avoids exposing pop-out UI until product is ready; consumers can set `dockable={true}` without further API changes. Breaking change risk is low for runtime APIs (mostly additive props), but **docs TOC and example IDs** for Sidebar RHS changed.

## Related issue

- Related: [#707](https://github.com/Sitecore/blok/pull/707) — Editable error state
- Related: [#709](https://github.com/Sitecore/blok/pull/709) — Sidebar RHS update