### PR TITLE
[Fix]: Tooltip Provider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "@/app/globals.css";
 import { DirectionProvider } from "@/components/docsite/direction-provider";
 import { StructuredData } from "@/components/seo/structured-data";
 import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const baseUrl = (() => {
   const url =
@@ -110,12 +111,14 @@ export default function RootLayout({
       </head>
       <body className="flex grow">
         <StructuredData />
-        <DirectionProvider>
-          {children}
-          <Analytics />
-          <SpeedInsights />
-          <Toaster />
-        </DirectionProvider>
+        <TooltipProvider>
+          <DirectionProvider>
+            {children}
+            <Analytics />
+            <SpeedInsights />
+            <Toaster />
+          </DirectionProvider>
+        </TooltipProvider>
       </body>
     </html>
   );

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -21,11 +21,7 @@ function TooltipProvider({
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({


### PR DESCRIPTION
## Summary
Removes Tooltip Provider from the Tooltip sub component.

## Description
The `TooltipProvider` nested within the Tooltip was removed. A common Tooltip Provider was added to the registry site