### PR TITLE
[fix] mount TooltipProvider in root layout and update installation guide

### DIFF
--- a/src/app/content/ui/tooltip/tooltip.tsx
+++ b/src/app/content/ui/tooltip/tooltip.tsx
@@ -2,21 +2,18 @@ import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 
 export default function TooltipDemo() {
   return (
-    <TooltipProvider>
-      <div className="flex gap-4">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="outline">Hover</Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Add to library</TooltipContent>
-        </Tooltip>
-      </div>
-    </TooltipProvider>
+    <div className="flex gap-4">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover</Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Add to library</TooltipContent>
+      </Tooltip>
+    </div>
   );
 }

--- a/src/app/demo/[name]/ui/tooltip.tsx
+++ b/src/app/demo/[name]/ui/tooltip.tsx
@@ -1,12 +1,52 @@
+import { CodeBlock } from "@/components/code-block";
+
+const ROOT_LAYOUT_TOOLTIP_SNIPPET = `import { TooltipProvider } from "@/components/ui/tooltip"
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head />
+      <body>
+        <TooltipProvider>
+          <main>{children}</main>
+        </TooltipProvider>
+      </body>
+    </html>
+  )
+}`;
+
 export const tooltip = {
   name: "tooltip",
   preview: {
     defaultComponent: "tooltip",
   },
+  installation: {
+    post: (
+      <div className="flex flex-col gap-3 pt-3">
+        <h3 className="font-semibold text-lg tracking-tight">
+          Add the TooltipProvider component.
+        </h3>
+        <p className="text-lg text-muted-foreground">
+          Mount in your root layout{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-md">
+            src/app/layout.tsx
+          </code>{" "}
+          so tooltips can render anywhere in the app.
+        </p>
+        <div className="overflow-hidden rounded-lg">
+          <CodeBlock
+            code={ROOT_LAYOUT_TOOLTIP_SNIPPET}
+            className="rounded-none border-0 shadow-none"
+            copyCodeContext={{ section: "installation", page_name: "tooltip" }}
+          />
+        </div>
+      </div>
+    ),
+  },
   usage: {
     usage: [
-      `import {\n  TooltipProvider,\n  Tooltip,\n  TooltipTrigger,\n  TooltipContent\n} from "@/components/ui/tooltip";`,
-      `<TooltipProvider>\n <Tooltip>\n   <TooltipTrigger asChild>\n    <Button variant="outline">Hover</Button>\n   </TooltipTrigger>\n   <TooltipContent side="bottom">Add to library</TooltipContent>\n  </Tooltip>\n</TooltipProvider>`,
+      `import {\n  Tooltip,\n  TooltipTrigger,\n  TooltipContent\n} from "@/components/ui/tooltip";`,
+      `<Tooltip>\n  <TooltipTrigger asChild>\n    <Button variant="outline">Hover</Button>\n  </TooltipTrigger>\n  <TooltipContent side="bottom">Add to library</TooltipContent>\n</Tooltip>`,
     ],
   },
 };


### PR DESCRIPTION
- Remove TooltipProvider from the tooltip demo so usage matches the global setup pattern.
- Add tooltip installation docs (aligned with Sonner) instructing consumers to mount TooltipProvider in src/app/layout.tsx.
- Update usage examples to show only Tooltip, TooltipTrigger, and TooltipContent.