### PR TITLE
moderate Accessibility issues fixes - 6/9/26

### DIFF
--- a/src/app/(registry)/bloks/[name]/page.tsx
+++ b/src/app/(registry)/bloks/[name]/page.tsx
@@ -31,9 +31,9 @@ export default async function BlokItemPage({
       <div className="flex items-center justify-between">
         <div>
           <div className="py-10 flex flex-col gap-6">
-            <h2 className="font-semibold text-4xl wrap-break-words">
+            <h1 className="font-semibold text-4xl wrap-break-words">
               {component.title}
-            </h2>
+            </h1>
             <p className="text-lg text-subtle-text wrap-break-words">
               {component.description}
             </p>

--- a/src/app/(registry)/layout.tsx
+++ b/src/app/(registry)/layout.tsx
@@ -25,12 +25,12 @@ export default function RegistryLayout({
     <GainsightProvider>
       <PageViewTracker />
       <div className="flex min-h-screen flex-col w-full bg-sidebar">
-        <header
+        <div
           className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full"
           style={{ transform: "translateZ(0)", backfaceVisibility: "hidden" }}
         >
           <TopBar />
-        </header>
+        </div>
 
         <div className="flex flex-1 relative mt-12 bg-sidebar">
           <SidebarProvider

--- a/src/app/(registry)/layout.tsx
+++ b/src/app/(registry)/layout.tsx
@@ -25,12 +25,13 @@ export default function RegistryLayout({
     <GainsightProvider>
       <PageViewTracker />
       <div className="flex min-h-screen flex-col w-full bg-sidebar">
-        <div
+        <header
+          aria-label="Site header"
           className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full"
           style={{ transform: "translateZ(0)", backfaceVisibility: "hidden" }}
         >
           <TopBar />
-        </div>
+        </header>
 
         <div className="flex flex-1 relative mt-12 bg-sidebar">
           <SidebarProvider

--- a/src/app/(registry)/mcp/page.tsx
+++ b/src/app/(registry)/mcp/page.tsx
@@ -29,7 +29,7 @@ const CursorConfigurationCode = `{
 
 export default function MCPPage() {
   return (
-    <main className="w-full">
+    <div className="w-full">
       <div className="px-4 sm:px-8 md:px-32 max-w-[1250px] mx-auto">
         <div className="flex flex-col space-y-5 p-5 md:p-10">
           <Breadcrumb>
@@ -474,6 +474,6 @@ args = ["shadcn@latest", "mcp"]`}
           </ol>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(registry)/migration/page.tsx
+++ b/src/app/(registry)/migration/page.tsx
@@ -145,7 +145,7 @@ const FAQ = [
 
 export default function MigrationPage() {
   return (
-    <main className="w-full">
+    <div className="w-full">
       <div className="px-4 sm:px-8 md:px-32 max-w-[1250px] mx-auto">
         <div className="flex flex-col space-y-5 p-5 md:p-10">
           <Breadcrumb>
@@ -311,6 +311,6 @@ export default function MigrationPage() {
           </ul>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(registry)/page.tsx
+++ b/src/app/(registry)/page.tsx
@@ -20,7 +20,7 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <main className="w-full bg-subtle-bg">
+    <div className="w-full bg-subtle-bg">
       <div className="bg-body-bg px-32 flex justify-center">
         <div className="flex flex-col space-y-12 py-20 md:py-30 w-full max-w-[1250px]">
           <div className="flex flex-col space-y-6">
@@ -382,6 +382,6 @@ export default function MyComponent() {
           </p>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/(registry)/primitives/[name]/page.tsx
+++ b/src/app/(registry)/primitives/[name]/page.tsx
@@ -31,9 +31,9 @@ export default async function PrimitiveItemPage({
       <div className="flex items-center justify-between">
         <div>
           <div className="py-10 flex flex-col gap-6">
-            <h2 className="font-semibold text-4xl wrap-break-words">
+            <h1 className="font-semibold text-4xl wrap-break-words">
               {component.title}
-            </h2>
+            </h1>
             <p className="text-lg text-subtle-text wrap-break-words">
               {component.description}
             </p>

--- a/src/app/(registry)/rtl/page.tsx
+++ b/src/app/(registry)/rtl/page.tsx
@@ -83,7 +83,7 @@ const RTL_LANGUAGES = [
 
 export default function RTLPage() {
   return (
-    <main className="w-full">
+    <div className="w-full">
       <div className="px-32 max-w-[1250px] mx-auto">
         <div className="flex flex-col space-y-5 p-5 md:p-10">
           <h1 className="font-semibold text-4xl md:text-4xl">
@@ -376,6 +376,6 @@ export function Sidebar() {
           </div>
         </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-brief-type.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-brief-type.tsx
@@ -495,7 +495,7 @@ export default function SidebarRHSBriefTypeDemo() {
       <SidebarRHSProvider>
         <div className="w-full h-full flex bg-body-bg">
           {/* Main content area */}
-          <main className="flex-1 overflow-auto p-4">
+          <div className="flex-1 overflow-auto p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -503,7 +503,7 @@ export default function SidebarRHSBriefTypeDemo() {
                 tabs for Overview, Usage, Comment, and Info.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-brief.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-brief.tsx
@@ -438,7 +438,7 @@ export default function SidebarRHSBriefDemo() {
       <SidebarRHSProvider>
         <div className="w-full h-full flex bg-body-bg">
           {/* Main content area */}
-          <main className="flex-1 overflow-auto p-4">
+          <div className="flex-1 overflow-auto p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -447,7 +447,7 @@ export default function SidebarRHSBriefDemo() {
                 them in action.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-component.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-component.tsx
@@ -536,7 +536,7 @@ export default function SidebarRHSContentDemo() {
       <SidebarRHSProvider>
         <div className="w-full h-full flex bg-body-bg">
           {/* Main content area */}
-          <main className="flex-1 overflow-auto p-4">
+          <div className="flex-1 overflow-auto p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -545,7 +545,7 @@ export default function SidebarRHSContentDemo() {
                 them in action.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-content.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-content.tsx
@@ -535,7 +535,7 @@ export default function SidebarRHSContentDemo() {
       <SidebarRHSProvider>
         <div className="w-full h-full flex bg-body-bg">
           {/* Main content area */}
-          <main className="flex-1 overflow-auto p-4">
+          <div className="flex-1 overflow-auto p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -544,7 +544,7 @@ export default function SidebarRHSContentDemo() {
                 them in action.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-fixed.tsx
@@ -57,7 +57,7 @@ export default function SidebarRHSFixedDemo() {
       <SidebarRHSProvider>
         <div className={`flex w-full ${EXAMPLE_HEIGHT} bg-body-bg`}>
           {/* Main content area */}
-          <main className="flex-1 overflow-auto bg-subtle-bg p-4">
+          <div className="flex-1 overflow-auto bg-subtle-bg p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -65,7 +65,7 @@ export default function SidebarRHSFixedDemo() {
                 controls.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs-heading-with-tabs.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs-heading-with-tabs.tsx
@@ -538,7 +538,7 @@ export default function SidebarRHSHeadingWithTabsDemo() {
       <SidebarRHSProvider>
         <div className="w-full h-full flex bg-body-bg">
           {/* Main content area */}
-          <main className="flex-1 overflow-auto p-4">
+          <div className="flex-1 overflow-auto p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -547,7 +547,7 @@ export default function SidebarRHSHeadingWithTabsDemo() {
                 them in action.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/bloks/sidebar-rhs/sidebar-rhs.tsx
+++ b/src/app/content/bloks/sidebar-rhs/sidebar-rhs.tsx
@@ -50,7 +50,7 @@ export default function SidebarRHSDemo() {
       <SidebarRHSProvider>
         <div className={`flex w-full ${EXAMPLE_HEIGHT} bg-body-bg`}>
           {/* Main content area */}
-          <main className="flex-1 overflow-auto bg-subtle-bg p-4">
+          <div className="flex-1 overflow-auto bg-subtle-bg p-4">
             <div className="space-y-4">
               <h2 className="text-2xl font-bold">Main Content Area</h2>
               <p className="text-muted-foreground">
@@ -58,7 +58,7 @@ export default function SidebarRHSDemo() {
                 content as children of SidebarRHS.
               </p>
             </div>
-          </main>
+          </div>
 
           {/* Sidebar */}
           <SidebarRHS

--- a/src/app/content/ui/collapsible/collapsible.tsx
+++ b/src/app/content/ui/collapsible/collapsible.tsx
@@ -20,7 +20,7 @@ export default function CollapsibleDemo() {
         className="flex w-full flex-col gap-2 md:w-[350px]"
       >
         <div className="flex items-center justify-between gap-4 px-4">
-          <h4 className="line-clamp-1 text-sm font-semibold">@products</h4>
+          <p className="line-clamp-1 text-sm font-semibold">@products</p>
           <CollapsibleTrigger asChild>
             <Button
               variant="ghost"

--- a/src/app/content/ui/scroll-area/scroll-area.tsx
+++ b/src/app/content/ui/scroll-area/scroll-area.tsx
@@ -11,7 +11,7 @@ export default function ScrollAreaDemo() {
     <div className="flex flex-col gap-6">
       <ScrollArea className="h-72 w-48 rounded-md border">
         <div className="p-4">
-          <h4 className="mb-4 text-sm leading-none font-medium">Tags</h4>
+          <p className="mb-4 text-sm leading-none font-medium">Tags</p>
           {tags.map((tag) => (
             <React.Fragment key={tag}>
               <div className="text-sm">{tag}</div>

--- a/src/app/demo/[name]/page.tsx
+++ b/src/app/demo/[name]/page.tsx
@@ -69,7 +69,7 @@ export default async function DemoPage({
               id={component.component as string}
               className="flex flex-col gap-6"
             >
-              <h3 className="font-semibold text-xl">{title}</h3>
+              <h2 className="font-semibold text-xl">{title}</h2>
               {component.pre}
               <DemoTab
                 code={entry.code}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,9 +5,9 @@ import Link from "next/link";
 export default function NotFound() {
   return (
     <div className="flex min-h-screen flex-col w-full bg-muted">
-      <header className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full">
+      <div className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full">
         <TopBar />
-      </header>
+      </div>
 
       <main className="flex flex-1 flex-col items-center justify-center mt-12 px-4">
         <div className="flex flex-col items-center text-center max-w-md">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,9 +5,12 @@ import Link from "next/link";
 export default function NotFound() {
   return (
     <div className="flex min-h-screen flex-col w-full bg-muted">
-      <div className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full">
+      <header
+        aria-label="Site header"
+        className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full"
+      >
         <TopBar />
-      </div>
+      </header>
 
       <main className="flex flex-1 flex-col items-center justify-center mt-12 px-4">
         <div className="flex flex-col items-center text-center max-w-md">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -6,7 +6,7 @@ export default function NotFound() {
   return (
     <div className="flex min-h-screen flex-col w-full bg-muted">
       <header
-        aria-label="Site header"
+        aria-label="Not Found Site header"
         className="fixed top-0 left-0 right-0 z-50 border-b bg-background border-border w-full"
       >
         <TopBar />

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -93,6 +93,8 @@ interface CodeBlockProps {
   lang?: string;
   showLineNumbers?: boolean;
   className?: string;
+  /** Accessible name for the code region landmark. Defaults to "Code sample". */
+  ariaLabel?: string;
   /** When set, copy triggers copy_code with normalized payload (section, path, page_type, component_name/block_name). */
   copyCodeContext?: CopyCodeContext;
   /** Hide the floating copy control (e.g. when copy is shown in a parent header). */
@@ -104,6 +106,7 @@ export function CodeBlock({
   lang = "tsx",
   showLineNumbers = true,
   className,
+  ariaLabel = "Code sample",
   copyCodeContext,
   hideCopyButton = false,
 }: CodeBlockProps) {
@@ -160,7 +163,7 @@ export function CodeBlock({
     <div
       dir="ltr"
       role="region"
-      aria-label="Code sample"
+      aria-label={ariaLabel}
       className={cn(
         "relative rounded-md bg-muted max-h-[400px] overflow-auto",
         className,

--- a/src/components/demo-tab.tsx
+++ b/src/components/demo-tab.tsx
@@ -164,6 +164,11 @@ export default function DemoTab({
         ) : (
           <CodeBlock
             code={code}
+            ariaLabel={
+              section === "examples" && exampleTitle
+                ? `${exampleTitle} code`
+                : "Preview code"
+            }
             className="rounded-t-none rounded-b-md"
             copyCodeContext={copyCodeContext}
           />

--- a/src/components/docsite/docsite-sidebar.tsx
+++ b/src/components/docsite/docsite-sidebar.tsx
@@ -309,9 +309,9 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   );
 }
 
-function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+function SidebarInset({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <main
+    <div
       data-slot="sidebar-inset"
       className={cn(
         "relative flex w-full flex-1 flex-col bg-background",

--- a/src/components/layout/right-sidebar.tsx
+++ b/src/components/layout/right-sidebar.tsx
@@ -124,7 +124,7 @@ export function RightSidebar({
   if (!hasContent) return null;
 
   return (
-    <aside className="hidden xl:block xl:sticky xl:top-12 xl:h-[calc(100vh-48px)] xl:w-[250px] xl:overflow-y-auto xl:shrink-0 p-10 space-y-8 bg-transparent">
+    <div className="hidden xl:block xl:sticky xl:top-12 xl:h-[calc(100vh-48px)] xl:w-[250px] xl:overflow-y-auto xl:shrink-0 p-10 space-y-8 bg-transparent">
       {/* Links Section */}
       {links && Object.keys(links).length > 0 && (
         <div className="space-y-2.5">
@@ -315,6 +315,6 @@ export function RightSidebar({
           </ul>
         </nav>
       )}
-    </aside>
+    </div>
   );
 }

--- a/src/components/ui/stack-navigation.tsx
+++ b/src/components/ui/stack-navigation.tsx
@@ -234,7 +234,7 @@ export function StackNavigation({
   pathname: providedPathname,
   onItemClick,
   ...props
-}: StackNavigationProps & React.ComponentProps<"aside">) {
+}: StackNavigationProps & React.ComponentProps<"div">) {
   // Use provided pathname or fall back to window.location.pathname
   const [clientPathname, setClientPathname] = React.useState("");
 
@@ -251,7 +251,7 @@ export function StackNavigation({
   const shadowClass = hasShadowNone ? "" : "shadow-base";
 
   return (
-    <aside
+    <div
       className={cn(
         !isHorizontal &&
           cn(
@@ -328,7 +328,7 @@ export function StackNavigation({
           {footer}
         </div>
       )}
-    </aside>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Addresses moderate accessibility findings from BrowserStack across the registry site, demo pages, and shared components. Changes focus on landmark structure, heading hierarchy, and accessible naming — no visual or layout changes.

## Fixes

### Landmark structure
- **Unique banner landmarks** — Added `aria-label="Site header"` to the fixed site header in the registry layout and 404 page so banner regions are distinguishable.
- **Single main landmark** — Removed nested `<main>` elements from registry pages (home, MCP, migration, RTL), `SidebarInset`, and Sidebar RHS demo previews so only the layout-level `#main-content` landmark remains.
- **Aside not nested in landmarks** — Replaced `<aside>` with `<div>` in the right sidebar TOC and `StackNavigation` to avoid complementary landmarks inside other landmark regions.

### Heading hierarchy
- **Page-level h1** — Promoted component/blok detail page titles from `<h2>` to `<h1>` (visual styling unchanged via existing classes).
- **Sequential headings in demos** — Updated demo example titles from `<h3>` to `<h2>` to maintain a logical heading order.
- **Demo content labels** — Replaced stray `<h4>` elements in Collapsible and Scroll Area demos with `<p>` where they were labels, not section headings.

### Accessible naming
- **Code blocks** — Added an `ariaLabel` prop to `CodeBlock` (default: `"Code sample"`) and passed contextual labels from `DemoTab` (e.g. `"Preview code"`, `"{exampleTitle} code"`).

## Files changed

- Registry layout and pages: `layout.tsx`, `not-found.tsx`, `page.tsx`, `mcp/page.tsx`, `migration/page.tsx`, `rtl/page.tsx`, `primitives/[name]/page.tsx`, `bloks/[name]/page.tsx`
- Demo pages: `demo/[name]/page.tsx`, Sidebar RHS demo content files
- Shared components: `code-block.tsx`, `demo-tab.tsx`, `docsite-sidebar.tsx`, `right-sidebar.tsx`, `stack-navigation.tsx`
- Demo content: `collapsible.tsx`, `scroll-area.tsx`