### PR TITLE
[Fix] filter dropdown panels stacking by removing default Popover forceMount - Staging PR

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -21,16 +21,14 @@ function PopoverContent({
   className,
   align = "center",
   sideOffset = 4,
-  forceMount = true,
   ...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
   return (
-    <PopoverPrimitive.Portal forceMount={forceMount}>
+    <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
-        forceMount={forceMount}
         className={cn(
           "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border px-3 py-2 shadow-md outline-hidden",
           className,


### PR DESCRIPTION
- Removes the default `forceMount={true}` from `PopoverContent` in `src/components/ui/popover.tsx`.
- Closed popover content was staying mounted in the DOM and rendering with `position: static`, which caused multi-select filter dropdown panels to stack in the page flow instead of floating over content.
- This was most visible on the Filter docs page (`/primitives/filter`), where multiple closed dropdowns added hundreds of pixels of ghost content and made the page appear to scroll with stacked filter menus.


A previous ARIA-related change set `forceMount={true}` by default on both `PopoverPrimitive.Portal` and `PopoverPrimitive.Content`. When closed, Radix did not apply floating positioning, so those panels remained visible in document flow.
