### PR TITLE
Accessibility issue fixes 

### DIFF
--- a/src/app/(registry)/page.tsx
+++ b/src/app/(registry)/page.tsx
@@ -80,7 +80,10 @@ export default function Home() {
       </div>
 
       <div className="px-32 w-full flex items-center flex-col">
-        <div className="flex flex-col space-y-3 py-20 md:pt-30  w-full max-w-[1250px]">
+        <section
+          aria-label="Getting started"
+          className="flex flex-col space-y-3 py-20 md:pt-30  w-full max-w-[1250px]"
+        >
           <h2 className="font-semibold text-3xl md:text-4xl">Prerequisites</h2>
           <p className="">
             Make sure you have the following tools installed before proceeding:
@@ -236,7 +239,7 @@ export default function Home() {
               . If you're familiar with that, you'll feel right at home!
             </AlertDescription>
           </Alert>
-        </div>
+        </section>
 
         <div
           id="step-1"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,9 +27,8 @@ function DropdownMenuTrigger({
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
-      aria-haspopup="true"
-      aria-expanded={false}
       {...props}
+      aria-haspopup="true"
     />
   );
 }
@@ -254,13 +253,12 @@ function DropdownMenuSubTrigger({
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
-      aria-haspopup="true"
-      aria-expanded={false}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:size-[0.8rem] [&_svg]:text-neutral-600",
         className,
       )}
       {...props}
+      aria-haspopup="true"
     >
       {children}
       <Icon path={mdiChevronRight} size={1.5} className="ml-auto" />

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -72,10 +72,9 @@ function NavigationMenuTrigger({
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
-      aria-haspopup="true"
-      aria-expanded={false}
       className={cn(navigationMenuTriggerStyle(), "group", className)}
       {...props}
+      aria-haspopup="true"
     >
       {children}{" "}
       <Icon

--- a/src/components/ui/stack-navigation.tsx
+++ b/src/components/ui/stack-navigation.tsx
@@ -107,6 +107,7 @@ export interface StackNavigationProps {
   renderDivider?: (divider: StackNavigationDivider, index: number) => ReactNode;
   className?: string;
   navClassName?: string;
+  "aria-label"?: string;
   width?: string;
   header?: ReactNode;
   footer?: ReactNode;
@@ -122,7 +123,7 @@ export interface StackNavigationProps {
 
   onItemClick?: (
     item: StackNavigationItem,
-    event: React.MouseEvent<HTMLAnchorElement>,
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
   ) => undefined | boolean;
 }
 
@@ -139,7 +140,7 @@ function DefaultNavItem({
   colorScheme?: "neutral" | "primary";
   onItemClick?: (
     item: StackNavigationItem,
-    event: React.MouseEvent<HTMLAnchorElement>,
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
   ) => undefined | boolean;
 }) {
   const isActive = pathname === item.path;
@@ -153,6 +154,56 @@ function DefaultNavItem({
       }
     }
   };
+
+  // Expandable controls use a button so aria-expanded can toggle and Enter/Space work.
+  if (onItemClick) {
+    return (
+      <button
+        type="button"
+        className={cn(
+          stackNavigationItemVariants({
+            orientation,
+            colorScheme,
+            isActive,
+            className: item.className,
+          }),
+        )}
+        aria-label={item.name}
+        aria-haspopup="true"
+        aria-expanded={isActive}
+        onClick={(e) => {
+          onItemClick(item, e);
+        }}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <div
+          aria-hidden="true"
+          className={cn(
+            "shrink-0 flex items-center justify-center",
+            "w-[22px] h-[22px]",
+          )}
+        >
+          {item.icon}
+        </div>
+
+        <span
+          className={cn(
+            !isHorizontal &&
+              "text-3xs text-center overflow-hidden text-ellipsis whitespace-nowrap w-full block leading-[150%] tracking-normal",
+            isHorizontal &&
+              "text-3xs text-center whitespace-nowrap leading-tight",
+          )}
+          title={item.name}
+        >
+          {item.name}
+        </span>
+
+        {!isHorizontal && item.badge && (
+          <div className="absolute top-1 right-1">{item.badge}</div>
+        )}
+      </button>
+    );
+  }
 
   return (
     <a
@@ -168,11 +219,7 @@ function DefaultNavItem({
       )}
       onContextMenu={(e) => e.preventDefault()}
       aria-label={item.name}
-      {...(onItemClick
-        ? { "aria-haspopup": true, "aria-expanded": isActive }
-        : {})}
     >
-      {/* Icon */}
       <div
         aria-hidden="true"
         className={cn(
@@ -183,7 +230,6 @@ function DefaultNavItem({
         {item.icon}
       </div>
 
-      {/* Text below icon */}
       <span
         className={cn(
           !isHorizontal &&
@@ -229,6 +275,7 @@ export function StackNavigation({
   renderDivider,
   className,
   navClassName,
+  "aria-label": ariaLabel,
   width = "w-[72px]",
   header,
   footer,
@@ -237,7 +284,7 @@ export function StackNavigation({
   pathname: providedPathname,
   onItemClick,
   ...props
-}: StackNavigationProps & React.ComponentProps<"div">) {
+}: StackNavigationProps & Omit<React.ComponentProps<"div">, "aria-label">) {
   // Use provided pathname or fall back to window.location.pathname
   const [clientPathname, setClientPathname] = React.useState("");
 
@@ -252,6 +299,7 @@ export function StackNavigation({
   const isHorizontal = orientation === "horizontal";
   const hasShadowNone = className?.includes("shadow-none");
   const shadowClass = hasShadowNone ? "" : "shadow-base";
+  const ListContainer = ariaLabel ? "nav" : "div";
 
   return (
     <div
@@ -284,8 +332,8 @@ export function StackNavigation({
           isHorizontal && "flex-1 overflow-x-auto",
         )}
       >
-        <nav
-          aria-label={isHorizontal ? "Sidebar navigation" : "Stack navigation"}
+        <ListContainer
+          {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
           className={cn(
             !isHorizontal && "flex flex-col gap-1",
             isHorizontal &&
@@ -323,7 +371,7 @@ export function StackNavigation({
               </div>
             );
           })}
-        </nav>
+        </ListContainer>
       </div>
 
       {/* Footer only for vertical */}


### PR DESCRIPTION
## Summary

- Fix **BCCL-1317 / BCCL-1318** for Dropdown and Navigation Menu: keep `aria-haspopup="true"` on triggers and let Radix own `aria-expanded` (removed hardcoded `aria-expanded={false}` so it toggles open/closed).
- Fix Stack Navigation expandable items: when `onItemClick` is used, default items render as buttons with `aria-haspopup` and toggling `aria-expanded`.
- Fix **BCCL-1321** landmark duplicates: Stack Navigation only renders a `<nav>` when an explicit `aria-label` is passed (otherwise a `<div>`).
- Fix Home Page landmark: wrap Prerequisites in `<section aria-label="Getting started">`.

## Components to retest

- Dropdown
- Navigation Menu
- Stack Navigation (default items with `onItemClick`, and landmark behavior with/without `aria-label`)
- Sidebar RHS (uses Stack Navigation)
- Home Page

## Notes

- Custom `renderItem` demos are unchanged on purpose (Code-tab examples). Consumers using custom expandable item UI must supply `aria-haspopup` / `aria-expanded` themselves.
- Product apps that need a nav landmark on Stack Navigation should pass a unique `aria-label`.