### PR TITLE
Accessibility audit fixes + carousel/React-Select rendering bugfixes

### DIFF
--- a/src/app/(registry)/page.tsx
+++ b/src/app/(registry)/page.tsx
@@ -80,7 +80,10 @@ export default function Home() {
       </div>
 
       <div className="px-32 w-full flex items-center flex-col">
-        <div className="flex flex-col space-y-3 py-20 md:pt-30  w-full max-w-[1250px]">
+        <section
+          aria-label="Getting started"
+          className="flex flex-col space-y-3 py-20 md:pt-30  w-full max-w-[1250px]"
+        >
           <h2 className="font-semibold text-3xl md:text-4xl">Prerequisites</h2>
           <p className="">
             Make sure you have the following tools installed before proceeding:
@@ -236,7 +239,7 @@ export default function Home() {
               . If you're familiar with that, you'll feel right at home!
             </AlertDescription>
           </Alert>
-        </div>
+        </section>
 
         <div
           id="step-1"

--- a/src/app/(registry)/page.tsx
+++ b/src/app/(registry)/page.tsx
@@ -345,6 +345,7 @@ export default function Home() {
             alias:
           </p>
           <CodeBlock
+            ariaLabel="Test setup App.jsx example"
             code={`import { Button } from "@/components/ui/button"
 
 export default function MyComponent() {

--- a/src/app/(registry)/rtl/page.tsx
+++ b/src/app/(registry)/rtl/page.tsx
@@ -242,6 +242,7 @@ export default function RTLPage() {
           </p>
           <CodeBlock
             code={UseDirectionCode}
+            ariaLabel="useDirection hook code"
             lang="tsx"
             showLineNumbers={true}
             className="bg-body-bg border"
@@ -310,6 +311,7 @@ export default function RTLPage() {
             <div>
               <h3 className="font-semibold text-xl mb-2">Basic Usage</h3>
               <CodeBlock
+                ariaLabel="Basic RTL DirectionProvider example"
                 code={`import { Direction } from "radix-ui";
 
 export default function App() {
@@ -330,6 +332,7 @@ export default function App() {
                 Using the Hook in Components
               </h3>
               <CodeBlock
+                ariaLabel="Sidebar RTL useDirection example"
                 code={`import { Direction } from "radix-ui";
 import { cn } from "@/lib/utils";
 
@@ -361,6 +364,7 @@ export function Sidebar() {
                 Code blocks should always remain LTR for readability:
               </p>
               <CodeBlock
+                ariaLabel="Keep code blocks LTR example"
                 code={`export function CodeBlock({ code }: { code: string }) {
   return (
     <div dir="ltr">

--- a/src/app/content/ui/carousel/carousel-negative-margin.tsx
+++ b/src/app/content/ui/carousel/carousel-negative-margin.tsx
@@ -18,7 +18,7 @@ export default function CarouselNegativeMarginDemo() {
           {Array.from({ length: 5 }).map((_, index) => (
             <CarouselItem key={index} className="pl-1 md:basis-1/2">
               <div className="p-1">
-                <Card className="bg-subtle-bg border-subtle-bg">
+                <Card className="bg-subtle-bg border-subtle-bg p-0">
                   <CardContent className="flex aspect-square items-center justify-center p-6">
                     <span className="text-2xl font-semibold text-body-text">
                       {index + 1}

--- a/src/app/content/ui/carousel/carousel-start-aligned.tsx
+++ b/src/app/content/ui/carousel/carousel-start-aligned.tsx
@@ -9,7 +9,7 @@ import {
 
 export default function CarouselStartAlignedDemo() {
   return (
-    <div className="w-full max-w-sm mx-auto">
+    <div className="w-full max-w-sm mx-auto px-20">
       <Carousel
         className="w-full"
         aria-label="Responsive cards carousel with start alignment"
@@ -21,7 +21,7 @@ export default function CarouselStartAlignedDemo() {
           {Array.from({ length: 5 }).map((_, index) => (
             <CarouselItem key={index} className="md:basis-1/2 lg:basis-1/3">
               <div className="p-1">
-                <Card className="bg-subtle-bg border-subtle-bg">
+                <Card className="bg-subtle-bg border-subtle-bg p-0">
                   <CardContent className="flex aspect-square items-center justify-center p-6">
                     <span className="text-3xl font-semibold text-body-text">
                       {index + 1}

--- a/src/app/content/ui/carousel/carousel.tsx
+++ b/src/app/content/ui/carousel/carousel.tsx
@@ -18,7 +18,7 @@ export default function CarouselDemo() {
           {Array.from({ length: 5 }).map((_, index) => (
             <CarouselItem key={index}>
               <div className="p-1">
-                <Card className="bg-subtle-bg border-subtle-bg">
+                <Card className="bg-subtle-bg border-subtle-bg p-0">
                   <CardContent className="flex aspect-square items-center justify-center p-6">
                     <span className="text-4xl font-semibold text-body-text">
                       {index + 1}

--- a/src/app/content/ui/combobox/combobox-multiple.tsx
+++ b/src/app/content/ui/combobox/combobox-multiple.tsx
@@ -37,9 +37,7 @@ export default function ComboboxMultipleDemo() {
           {(values: readonly string[]) => (
             <React.Fragment>
               {values.map((value: string) => (
-                <ComboboxChip key={value} aria-label="Remove chip">
-                  {value}
-                </ComboboxChip>
+                <ComboboxChip key={value}>{value}</ComboboxChip>
               ))}
               <ComboboxChipsInput aria-label="Combobox chips input" />
             </React.Fragment>

--- a/src/app/content/ui/popover/popover.tsx
+++ b/src/app/content/ui/popover/popover.tsx
@@ -24,25 +24,37 @@ export default function PopoverDemo() {
           <div className="grid gap-2">
             <div className="grid grid-cols-3 items-center gap-4">
               <Label htmlFor="width">Width</Label>
-              <Input id="width" defaultValue="100%" className="col-span-2" />
+              <Input
+                id="width"
+                defaultValue="100%"
+                autoComplete="off"
+                className="col-span-2"
+              />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
               <Label htmlFor="maxWidth">Max. width</Label>
               <Input
                 id="maxWidth"
                 defaultValue="300px"
+                autoComplete="off"
                 className="col-span-2"
               />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
               <Label htmlFor="height">Height</Label>
-              <Input id="height" defaultValue="25px" className="col-span-2" />
+              <Input
+                id="height"
+                defaultValue="25px"
+                autoComplete="off"
+                className="col-span-2"
+              />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
               <Label htmlFor="maxHeight">Max. height</Label>
               <Input
                 id="maxHeight"
                 defaultValue="none"
+                autoComplete="off"
                 className="col-span-2"
               />
             </div>

--- a/src/components/bloks/collaboration.tsx
+++ b/src/components/bloks/collaboration.tsx
@@ -288,6 +288,7 @@ export function Collaboration<T extends User = User>({
         <PopoverContent
           align="end"
           sideOffset={8}
+          aria-label={title}
           className="w-[368px] p-0 border-0 bg-transparent shadow-none"
         >
           {/* Users Panel */}
@@ -354,6 +355,7 @@ export function Collaboration<T extends User = User>({
                   align="center"
                   sideOffset={-8}
                   alignOffset={26}
+                  aria-label="Add users"
                   className="w-[420px] p-0 border-0 bg-transparent shadow-none"
                 >
                   {/* Add Users Panel */}

--- a/src/components/bloks/collaboration.tsx
+++ b/src/components/bloks/collaboration.tsx
@@ -379,6 +379,7 @@ export function Collaboration<T extends User = User>({
                           size="icon-sm"
                           onClick={() => setIsAddUsersOpen(false)}
                           className="text-muted-foreground hover:text-foreground -mr-1"
+                          aria-label="Close add users popover"
                         >
                           <Icon path={mdiClose} className="size-4" />
                         </Button>

--- a/src/components/bloks/collaboration.tsx
+++ b/src/components/bloks/collaboration.tsx
@@ -136,35 +136,29 @@ function UserListItem({
   onAdd?: () => void;
   onRemove?: () => void;
 }) {
-  const [isHovered, setIsHovered] = useState(false);
-
   return (
-    <div
-      className="flex items-center justify-between py-2 px-1 rounded-md hover:bg-neutral-bg transition-colors"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div className="flex items-center gap-3">
+    <div className="group flex min-w-0 items-center justify-between gap-2 py-2 px-1 rounded-md hover:bg-neutral-bg transition-colors">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
         <Avatar className="size-8">
           <AvatarImage src={user.avatarUrl} alt={user.name} />
           <AvatarFallback className="text-xs bg-muted">
             {getInitials(user.name)}
           </AvatarFallback>
         </Avatar>
-        <span className="text-sm font-medium">
+        <span className="truncate text-sm font-medium">
           {user.name}
           {isCurrentUser && (
             <span className="text-muted-foreground"> (You)</span>
           )}
         </span>
       </div>
-      {isAdded && isHovered && onRemove && (
+      {isAdded && onRemove && (
         <Button
           variant="link"
           size="xs"
           colorScheme="primary"
           onClick={onRemove}
-          className="h-auto py-0.5 px-2 no-underline hover:no-underline font-bold"
+          className="h-auto py-0.5 px-2 no-underline hover:no-underline font-bold opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
         >
           Remove
         </Button>
@@ -313,7 +307,7 @@ export function Collaboration<T extends User = User>({
                   {emptyStateMessage}
                 </div>
               ) : (
-                <div className="space-y-1 max-h-48 overflow-y-auto">
+                <div className="max-h-48 space-y-1 overflow-y-auto overflow-x-hidden">
                   {users.map((user) => {
                     const userId = getUserId(user as T);
                     const currentUserId = currentUser
@@ -411,7 +405,7 @@ export function Collaboration<T extends User = User>({
                         </SearchInput>
                       </div>
 
-                      <div className="space-y-1 max-h-48 overflow-y-auto">
+                      <div className="max-h-48 space-y-1 overflow-y-auto overflow-x-hidden">
                         {isSearching && (
                           <div className="text-sm text-muted-foreground py-4 text-center">
                             Searching...

--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -162,7 +162,7 @@ export function CodeBlock({
   return (
     <div
       dir="ltr"
-      role="region"
+      role={ariaLabel ? "region" : undefined}
       aria-label={ariaLabel}
       className={cn(
         "relative rounded-md bg-muted max-h-[400px] overflow-auto",

--- a/src/components/docsite/component-card.tsx
+++ b/src/components/docsite/component-card.tsx
@@ -11,7 +11,7 @@ const DemoWrapper = dynamic(() => import("@/components/demo-wrapper"), {
 
 export function ComponentCard({ component }: ComponentCardProps) {
   return (
-    <section>
+    <section aria-label="Component preview">
       <div id="starting-kit">
         <div className="w-full min-w-0 overflow-x-hidden">
           <DemoWrapper name={component.name} />

--- a/src/components/layout/topbar.tsx
+++ b/src/components/layout/topbar.tsx
@@ -522,7 +522,10 @@ export default function TopBar() {
 
           {/* Top navigation */}
           <nav aria-label="Top navigation">
-            <NavigationMenu className="hidden lg:flex">
+            <NavigationMenu
+              className="hidden lg:flex"
+              aria-label="Site navigation"
+            >
               <NavigationMenuList className="flex gap-3">
                 {navItems.map((item) => {
                   const normalizedPathname = pathname.replace(/\/$/, "") || "/";

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -35,29 +35,31 @@ function AccordionTrigger({
   actions?: React.ReactNode;
 }) {
   return (
-    <AccordionPrimitive.Header className="flex items-center hover:bg-blackAlpha-50 transition-colors w-full min-w-0">
-      <AccordionPrimitive.Trigger
-        data-slot="accordion-trigger"
-        className={cn(
-          "focus-visible:border-ring focus-visible:ring-ring/50 text-md font-regular flex flex-1 cursor-pointer items-center justify-between gap-4 px-2 py-4 text-left transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180 min-w-0",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-        <Icon
-          path={mdiChevronDown}
-          className="transition-transform duration-200 size-6 shrink-0"
-        />
-      </AccordionPrimitive.Trigger>
-      {actions && (
-        <div
-          className="flex items-center shrink-0 py-4 px-2"
-          onClick={(e) => e.stopPropagation()}
+    <AccordionPrimitive.Header asChild>
+      <div className="flex items-center hover:bg-blackAlpha-50 transition-colors w-full min-w-0">
+        <AccordionPrimitive.Trigger
+          data-slot="accordion-trigger"
+          className={cn(
+            "focus-visible:border-ring focus-visible:ring-ring/50 text-md font-regular flex flex-1 cursor-pointer items-center justify-between gap-4 px-2 py-4 text-left transition-all outline-none focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180 min-w-0",
+            className,
+          )}
+          {...props}
         >
-          {actions}
-        </div>
-      )}
+          {children}
+          <Icon
+            path={mdiChevronDown}
+            className="transition-transform duration-200 size-6 shrink-0"
+          />
+        </AccordionPrimitive.Trigger>
+        {actions && (
+          <div
+            className="flex items-center shrink-0 py-4 px-2"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {actions}
+          </div>
+        )}
+      </div>
     </AccordionPrimitive.Header>
   );
 }

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -92,6 +92,7 @@ function Calendar({
       className={cn("p-3", className)}
       captionLayout={captionLayout}
       labels={{
+        labelNav: () => "Month navigation",
         ...labels,
         ...(monthDropdownAriaLabel != null && !labels?.labelMonthDropdown
           ? { labelMonthDropdown: () => monthDropdownAriaLabel }

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -129,7 +129,11 @@ function DatePickerSimple(props: DatePickerSimpleProps) {
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverContent
+        className="w-auto p-0"
+        align="start"
+        aria-label="Choose date"
+      >
         <Calendar
           {...calendarProps}
           mode="single"
@@ -251,7 +255,11 @@ function DatePickerWithRange(props: DatePickerWithRangeProps) {
           {triggerLabel}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
+      <PopoverContent
+        className="w-auto p-0"
+        align="start"
+        aria-label="Choose date"
+      >
         <Calendar
           {...calendarProps}
           mode="range"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,9 +27,8 @@ function DropdownMenuTrigger({
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
-      aria-haspopup="true"
-      aria-expanded={false}
       {...props}
+      aria-haspopup="true"
     />
   );
 }
@@ -254,13 +253,12 @@ function DropdownMenuSubTrigger({
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
-      aria-haspopup="true"
-      aria-expanded={false}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:size-[0.8rem] [&_svg]:text-neutral-600",
         className,
       )}
       {...props}
+      aria-haspopup="true"
     >
       {children}
       <Icon path={mdiChevronRight} size={1.5} className="ml-auto" />

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,6 +27,7 @@ function DropdownMenuTrigger({
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
+      aria-haspopup="true"
       {...props}
     />
   );
@@ -252,6 +253,7 @@ function DropdownMenuSubTrigger({
     <DropdownMenuPrimitive.SubTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
+      aria-haspopup="true"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:size-[0.8rem] [&_svg]:text-neutral-600",
         className,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -28,6 +28,7 @@ function DropdownMenuTrigger({
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
       aria-haspopup="true"
+      aria-expanded={false}
       {...props}
     />
   );
@@ -254,6 +255,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       aria-haspopup="true"
+      aria-expanded={false}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:size-[0.8rem] [&_svg]:text-neutral-600",
         className,

--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -452,6 +452,7 @@ const FilterSingleSelect = React.forwardRef<
               </PopoverTrigger>
               <PopoverContent
                 align="start"
+                aria-label={ariaLabels?.listbox ?? groupLabel ?? placeholder}
                 className={cn(
                   FILTER_DROPDOWN_WIDTH,
                   FILTER_DROPDOWN_CONTAINER,
@@ -615,7 +616,10 @@ const FilterSingleSelect = React.forwardRef<
                 )}
               </span>
             </SelectTrigger>
-            <FilterSingleSelectContent align="start">
+            <FilterSingleSelectContent
+              align="start"
+              aria-label={ariaLabels?.listbox ?? groupLabel ?? placeholder}
+            >
               {groups ? (
                 groups.map((group) => (
                   <SelectGroup key={group.label}>
@@ -1025,6 +1029,7 @@ const FilterMultiSelect = React.forwardRef<
               </Button>
             </PopoverTrigger>
             <PopoverContent
+              aria-label={ariaLabels?.listbox ?? groupLabel ?? placeholder}
               className={cn(
                 FILTER_DROPDOWN_WIDTH,
                 FILTER_DROPDOWN_CONTAINER,

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -72,6 +72,7 @@ function NavigationMenuTrigger({
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
       aria-haspopup="true"
+      aria-expanded={false}
       className={cn(navigationMenuTriggerStyle(), "group", className)}
       {...props}
     >

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -18,6 +18,7 @@ function NavigationMenu({
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
       data-viewport={viewport}
+      aria-label="Navigation menu"
       className={cn(
         "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
         className,

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -71,6 +71,7 @@ function NavigationMenuTrigger({
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
+      aria-haspopup="true"
       className={cn(navigationMenuTriggerStyle(), "group", className)}
       {...props}
     >

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -72,10 +72,9 @@ function NavigationMenuTrigger({
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
-      aria-haspopup="true"
-      aria-expanded={false}
       className={cn(navigationMenuTriggerStyle(), "group", className)}
       {...props}
+      aria-haspopup="true"
     >
       {children}{" "}
       <Icon

--- a/src/components/ui/select-react.tsx
+++ b/src/components/ui/select-react.tsx
@@ -227,6 +227,10 @@ function SelectReact<
         ...base,
         backgroundColor: undefined,
       }),
+      menuPortal: (base) => ({
+        ...base,
+        zIndex: 50,
+      }),
       menuList: (base) => ({
         ...base,
         padding: undefined,
@@ -298,6 +302,8 @@ function SelectReact<
       components={mergedComponents}
       isDisabled={isDisabled}
       isOptionDisabled={(option) => !!(option as SelectReactOption).disabled}
+      // Portal the menu so it isn't clipped by overflow-hidden ancestors (e.g. demo previews).
+      menuPortalTarget={typeof document !== "undefined" ? document.body : null}
       {...props}
     />
   );

--- a/src/components/ui/select-react.tsx
+++ b/src/components/ui/select-react.tsx
@@ -302,7 +302,6 @@ function SelectReact<
       components={mergedComponents}
       isDisabled={isDisabled}
       isOptionDisabled={(option) => !!(option as SelectReactOption).disabled}
-      // Portal the menu so it isn't clipped by overflow-hidden ancestors (e.g. demo previews).
       menuPortalTarget={typeof document !== "undefined" ? document.body : null}
       {...props}
     />

--- a/src/components/ui/stack-navigation.tsx
+++ b/src/components/ui/stack-navigation.tsx
@@ -107,6 +107,7 @@ export interface StackNavigationProps {
   renderDivider?: (divider: StackNavigationDivider, index: number) => ReactNode;
   className?: string;
   navClassName?: string;
+  "aria-label"?: string;
   width?: string;
   header?: ReactNode;
   footer?: ReactNode;
@@ -122,7 +123,7 @@ export interface StackNavigationProps {
 
   onItemClick?: (
     item: StackNavigationItem,
-    event: React.MouseEvent<HTMLAnchorElement>,
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
   ) => undefined | boolean;
 }
 
@@ -139,7 +140,7 @@ function DefaultNavItem({
   colorScheme?: "neutral" | "primary";
   onItemClick?: (
     item: StackNavigationItem,
-    event: React.MouseEvent<HTMLAnchorElement>,
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
   ) => undefined | boolean;
 }) {
   const isActive = pathname === item.path;
@@ -153,6 +154,56 @@ function DefaultNavItem({
       }
     }
   };
+
+  // Expandable controls use a button so aria-expanded can toggle and Enter/Space work.
+  if (onItemClick) {
+    return (
+      <button
+        type="button"
+        className={cn(
+          stackNavigationItemVariants({
+            orientation,
+            colorScheme,
+            isActive,
+            className: item.className,
+          }),
+        )}
+        aria-label={item.name}
+        aria-haspopup="true"
+        aria-expanded={isActive}
+        onClick={(e) => {
+          onItemClick(item, e);
+        }}
+        onContextMenu={(e) => e.preventDefault()}
+      >
+        <div
+          aria-hidden="true"
+          className={cn(
+            "shrink-0 flex items-center justify-center",
+            "w-[22px] h-[22px]",
+          )}
+        >
+          {item.icon}
+        </div>
+
+        <span
+          className={cn(
+            !isHorizontal &&
+              "text-3xs text-center overflow-hidden text-ellipsis whitespace-nowrap w-full block leading-[150%] tracking-normal",
+            isHorizontal &&
+              "text-3xs text-center whitespace-nowrap leading-tight",
+          )}
+          title={item.name}
+        >
+          {item.name}
+        </span>
+
+        {!isHorizontal && item.badge && (
+          <div className="absolute top-1 right-1">{item.badge}</div>
+        )}
+      </button>
+    );
+  }
 
   return (
     <a
@@ -168,11 +219,7 @@ function DefaultNavItem({
       )}
       onContextMenu={(e) => e.preventDefault()}
       aria-label={item.name}
-      {...(onItemClick
-        ? { "aria-haspopup": true, "aria-expanded": isActive }
-        : {})}
     >
-      {/* Icon */}
       <div
         aria-hidden="true"
         className={cn(
@@ -183,7 +230,6 @@ function DefaultNavItem({
         {item.icon}
       </div>
 
-      {/* Text below icon */}
       <span
         className={cn(
           !isHorizontal &&
@@ -229,6 +275,7 @@ export function StackNavigation({
   renderDivider,
   className,
   navClassName,
+  "aria-label": ariaLabel,
   width = "w-[72px]",
   header,
   footer,
@@ -237,7 +284,7 @@ export function StackNavigation({
   pathname: providedPathname,
   onItemClick,
   ...props
-}: StackNavigationProps & React.ComponentProps<"div">) {
+}: StackNavigationProps & Omit<React.ComponentProps<"div">, "aria-label">) {
   // Use provided pathname or fall back to window.location.pathname
   const [clientPathname, setClientPathname] = React.useState("");
 
@@ -252,6 +299,7 @@ export function StackNavigation({
   const isHorizontal = orientation === "horizontal";
   const hasShadowNone = className?.includes("shadow-none");
   const shadowClass = hasShadowNone ? "" : "shadow-base";
+  const ListContainer = ariaLabel ? "nav" : "div";
 
   return (
     <div
@@ -284,8 +332,8 @@ export function StackNavigation({
           isHorizontal && "flex-1 overflow-x-auto",
         )}
       >
-        <nav
-          aria-label={isHorizontal ? "Sidebar navigation" : "Stack navigation"}
+        <ListContainer
+          {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
           className={cn(
             !isHorizontal && "flex flex-col gap-1",
             isHorizontal &&
@@ -323,7 +371,7 @@ export function StackNavigation({
               </div>
             );
           })}
-        </nav>
+        </ListContainer>
       </div>
 
       {/* Footer only for vertical */}

--- a/src/components/ui/stack-navigation.tsx
+++ b/src/components/ui/stack-navigation.tsx
@@ -285,6 +285,7 @@ export function StackNavigation({
         )}
       >
         <nav
+          aria-label={isHorizontal ? "Sidebar navigation" : "Stack navigation"}
           className={cn(
             !isHorizontal && "flex flex-col gap-1",
             isHorizontal &&

--- a/src/components/ui/stack-navigation.tsx
+++ b/src/components/ui/stack-navigation.tsx
@@ -168,6 +168,9 @@ function DefaultNavItem({
       )}
       onContextMenu={(e) => e.preventDefault()}
       aria-label={item.name}
+      {...(onItemClick
+        ? { "aria-haspopup": true, "aria-expanded": isActive }
+        : {})}
     >
       {/* Icon */}
       <div

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -100,14 +100,17 @@ export function TimePicker({
       >
         <div className="flex items-center gap-2">
           <div className="flex flex-col gap-2">
-            <label className="text-xs text-muted-foreground font-medium">
+            <label
+              htmlFor="time-picker-hour"
+              className="text-xs text-muted-foreground font-medium"
+            >
               Hour
             </label>
             <Select
               value={time?.hour || "12"}
               onValueChange={(val) => handleTimeChange("hour", val)}
             >
-              <SelectTrigger className="w-[70px]">
+              <SelectTrigger id="time-picker-hour" className="w-[70px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="p-0 min-w-20">
@@ -123,14 +126,17 @@ export function TimePicker({
           <span className="text-2xl font-bold mt-6">:</span>
 
           <div className="flex flex-col gap-2">
-            <label className="text-xs text-muted-foreground font-medium">
+            <label
+              htmlFor="time-picker-minute"
+              className="text-xs text-muted-foreground font-medium"
+            >
               Minute
             </label>
             <Select
               value={time?.minute || "00"}
               onValueChange={(val) => handleTimeChange("minute", val)}
             >
-              <SelectTrigger className="w-[70px]">
+              <SelectTrigger id="time-picker-minute" className="w-[70px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="p-0 min-w-20 max-h-[400px]">
@@ -144,7 +150,10 @@ export function TimePicker({
           </div>
 
           <div className="flex flex-col gap-2">
-            <label className="text-xs text-muted-foreground font-medium">
+            <label
+              htmlFor="time-picker-period"
+              className="text-xs text-muted-foreground font-medium"
+            >
               Period
             </label>
             <Select
@@ -153,7 +162,7 @@ export function TimePicker({
                 handleTimeChange("period", val as "AM" | "PM")
               }
             >
-              <SelectTrigger className="w-[75px]">
+              <SelectTrigger id="time-picker-period" className="w-[75px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -93,7 +93,11 @@ export function TimePicker({
           />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-4" align="start">
+      <PopoverContent
+        className="w-auto p-4"
+        align="start"
+        aria-label="Choose time"
+      >
         <div className="flex items-center gap-2">
           <div className="flex flex-col gap-2">
             <label className="text-xs text-muted-foreground font-medium">

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -103,7 +103,7 @@ export function TimePicker({
               value={time?.hour || "12"}
               onValueChange={(val) => handleTimeChange("hour", val)}
             >
-              <SelectTrigger className="w-[70px]">
+              <SelectTrigger className="w-[70px]" aria-label="Hour">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="p-0 min-w-20">
@@ -126,7 +126,7 @@ export function TimePicker({
               value={time?.minute || "00"}
               onValueChange={(val) => handleTimeChange("minute", val)}
             >
-              <SelectTrigger className="w-[70px]">
+              <SelectTrigger className="w-[70px]" aria-label="Minute">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="p-0 min-w-20 max-h-[400px]">
@@ -149,7 +149,7 @@ export function TimePicker({
                 handleTimeChange("period", val as "AM" | "PM")
               }
             >
-              <SelectTrigger className="w-[75px]">
+              <SelectTrigger className="w-[75px]" aria-label="Period">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary

This Pull Request is primarily an accessibility (a11y) audit pass across core components, plus rendering bugfixes for the carousel and the React-Select-based menu.

## Accessibility fixes
- Add `aria-expanded` and `aria-haspopup` to menus with dropdowns
- Ensure landmarks have a unique role / accessible name (role + label/title)
- Give ARIA `dialog`/`alertdialog` nodes an accessible name
- Associate labels correctly with their form controls
- Use valid `autocomplete` attribute values
- Fix non-sequential heading levels (only increase by one)
- Make scrollable regions keyboard-accessible
- Fix "buttons must have discernible text"
- Remove unsupported `aria-label` on a `div` with no valid role

Touched components include `accordion`, `dropdown-menu`, `navigation-menu`, `filter`, `date-picker`, `time-picker`, `calendar`, `stack-navigation`, `topbar`, and several registry/demo pages.

## Bugfixes
- **Carousel:** restore navigation arrows, re-add start-aligned gutter padding, and zero card padding so numbers center correctly on narrow slides
- **React-Select menu:** portal the menu so `overflow-hidden` wrappers no longer clip it (`select-react.tsx`, combobox/popover demos)