### PR TITLE
fix(ui): use shared SelectContent in FilterSingleSelect

### DIFF
--- a/src/components/ui/filter.tsx
+++ b/src/components/ui/filter.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/search-input";
 import {
   Select,
+  SelectContent,
   SelectGroup,
   SelectItem,
   SelectLabel,
@@ -26,7 +27,6 @@ import {
 import { Icon } from "@/lib/icon";
 import { cn } from "@/lib/utils";
 import { mdiCheck, mdiChevronDown, mdiClose, mdiMagnify } from "@mdi/js";
-import { Select as SelectPrimitive } from "radix-ui";
 import * as React from "react";
 import type { ComponentProps } from "react";
 
@@ -43,32 +43,21 @@ function FilterSingleSelectContent({
   children,
   position = "popper",
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectContent>) {
   return (
-    <SelectPrimitive.Portal>
-      <SelectPrimitive.Content
-        data-slot="filter-single-select-content"
-        className={cn(
-          FILTER_DROPDOWN_WIDTH,
-          FILTER_DROPDOWN_CONTAINER,
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) max-h-80 origin-(--radix-select-content-transform-origin) overflow-hidden outline-none",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className,
-        )}
-        position={position}
-        {...props}
-      >
-        <SelectPrimitive.Viewport
-          className={cn(
-            "p-2 max-h-80 overflow-y-auto w-full scroll-my-1",
-            position === "popper" && "w-full",
-          )}
-        >
-          {children}
-        </SelectPrimitive.Viewport>
-      </SelectPrimitive.Content>
-    </SelectPrimitive.Portal>
+    <SelectContent
+      data-slot="filter-single-select-content"
+      className={cn(
+        FILTER_DROPDOWN_WIDTH,
+        FILTER_DROPDOWN_CONTAINER,
+        "min-w-0 max-h-80 overflow-hidden p-0 [&_[data-slot=select-viewport]]:h-auto [&_[data-slot=select-viewport]]:min-w-0 [&_[data-slot=select-viewport]]:p-2 [&_[data-slot=select-viewport]]:max-h-80",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      {children}
+    </SelectContent>
   );
 }
 


### PR DESCRIPTION
## Summary
- In the shared Blok `FilterSingleSelect` flow, a helper named `FilterSingleSelectContent` was used instead of the shared `SelectContent` exported from the shared Select implementation. This caused a runtime failure when rendering the dropdown content:

  `Error: SelectContent must be used within Select`
  
  
<img width="601" height="156" alt="image-20260717-122049" src="https://github.com/user-attachments/assets/c4663ee5-6a6f-4cf3-b6c5-d458525f293c" />


  The error occurs in the `SelectContent` component and breaks the filter rendering path.
- Update `FilterSingleSelectContent` to compose the shared `SelectContent` instead of importing Radix Select primitives directly, so the dropdown keeps Select context under Module Federation and still portals through the shared scoped container.