### PR TITLE
fixed the moderate accessibility issues

### DIFF
--- a/src/app/(registry)/layout.tsx
+++ b/src/app/(registry)/layout.tsx
@@ -14,7 +14,6 @@ import {
 import TopBar from "@/components/layout/topbar";
 import { GainsightProvider } from "@/components/telemetry/gainsight-provider";
 import { PageViewTracker } from "@/components/telemetry/page-view-tracker";
-import { Toaster } from "@/components/ui/sonner";
 
 export default function RegistryLayout({
   children,
@@ -58,7 +57,6 @@ export default function RegistryLayout({
             </SidebarInset>
           </SidebarProvider>
         </div>
-        <Toaster />
       </div>
     </GainsightProvider>
   );

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -68,6 +68,14 @@ export function InBuiltDropdown({
   );
 }
 
+function defaultMonthNavLabel(
+  mode: React.ComponentProps<typeof DayPicker>["mode"],
+): string {
+  if (mode === "range") return "Date range month navigation";
+  if (mode === "multiple") return "Multiple dates month navigation";
+  return "Month navigation";
+}
+
 function Calendar({
   className,
   classNames,
@@ -78,11 +86,13 @@ function Calendar({
   components,
   labels,
   monthDropdownAriaLabel,
+  navAriaLabel,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"];
   /** Sets `labels.labelMonthDropdown` for dropdown caption layouts (month `<select>` / custom trigger). */
   monthDropdownAriaLabel?: string;
+  navAriaLabel?: string;
 }) {
   const defaultClassNames = getDefaultClassNames();
 
@@ -92,10 +102,13 @@ function Calendar({
       className={cn("p-3", className)}
       captionLayout={captionLayout}
       labels={{
-        labelNav: () => "Month navigation",
+        labelNav: () => defaultMonthNavLabel(props.mode),
         ...labels,
         ...(monthDropdownAriaLabel != null && !labels?.labelMonthDropdown
           ? { labelMonthDropdown: () => monthDropdownAriaLabel }
+          : {}),
+        ...(navAriaLabel != null && !labels?.labelNav
+          ? { labelNav: () => navAriaLabel }
           : {}),
       }}
       formatters={{

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -10,6 +10,7 @@ function NavigationMenu({
   className,
   children,
   viewport = true,
+  "aria-label": ariaLabel,
   ...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
   viewport?: boolean;
@@ -18,7 +19,9 @@ function NavigationMenu({
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
       data-viewport={viewport}
-      aria-label="Navigation menu"
+      aria-label={
+        ariaLabel ?? (viewport ? "Navigation menu" : "Inline navigation menu")
+      }
       className={cn(
         "group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
         className,


### PR DESCRIPTION
## fixed the moderate accessibility issues

- **[fix]:** [BCCL-1347](https://sitecore.atlassian.net/browse/BCCL-1347) - Moderate Issues - Accessibility Audit - 21.07.2026

**Summary**

- Remove the duplicate Sonner <Toaster /> from the registry layout so only the root-layout toaster remains (fixes identical Notifications alt+T landmarks on /primitives/command and other registry pages).
- Make Calendar month-nav landmarks unique by selection mode (Month navigation / Date range month navigation / Multiple dates month navigation), with optional navAriaLabel override.
- Make NavigationMenu default aria-label unique by viewport (Navigation menu vs Inline navigation menu), while still allowing custom aria-label.

**Files changed**

- src/app/(registry)/layout.tsx
- src/components/ui/calendar.tsx
- src/components/ui/navigation-menu.tsx